### PR TITLE
fix(p0): unblock portal CI + build after Rename & Reseed split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,39 +7,32 @@ on:
     branches: [main]
 
 jobs:
-  backend:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-
-      - name: Install dependencies
-        run: pip install -e ".[dev]"
-
-      - name: Lint
-        run: ruff check .
-
-      - name: Run tests
-        run: pytest tests/ -x -q
-
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: portal/package-lock.json
+          cache: pnpm
 
       - name: Install dependencies
-        run: cd portal && npm ci
+        run: pnpm install --frozen-lockfile
+
+      # TODO: re-enable `pnpm lint` once the 174 pre-existing eslint errors
+      # are cleared (P2 in audit_deep_portails_2026_04_29). Skipping for now
+      # to keep the build/tests gate honest after the Rename & Reseed split.
 
       - name: TypeScript check
-        run: cd portal && npx tsc --noEmit
+        run: pnpm exec tsc --noEmit
+
+      - name: Run tests
+        run: pnpm test
 
       - name: Build
-        run: cd portal && npm run build
+        run: pnpm build

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,14 +1,13 @@
 /* GISPulse portal tokens.
  *
- * Imports the shared design-system tokens (typography, spacing, radius,
- * shadow scales) so portal/src/index.css references like
- * `var(--gp-text-label-xs)` actually resolve. Portal-specific overrides
- * for brand/node/geom/status/surface follow below and intentionally
- * shadow the design-system defaults — the portal vocabulary
- * (--gp-node-source/transform/output/trigger/control/code) is finer
- * grained than the design-system one (--gp-node-dataset/capability).
+ * Portal-specific brand/node/geom/status/surface tokens. Typography,
+ * spacing, radius, sizing tokens (`--gp-text-label-*`, `--gp-spacing-*`,
+ * `--gp-width-*`) are defined in `src/index.css` since the
+ * Rename & Reseed split (2026-04-25); the previous shared
+ * `design-system/tokens.css` lived in the pre-split mono-repo and is
+ * gone. This file overrides nothing from index.css — it only adds
+ * portal-specific node/geom/status/surface vocabulary.
  */
-@import "../../../design-system/tokens.css";
 
 :root {
   /* Brand */


### PR DESCRIPTION
Closes the two P0 build/CI bloquants from `audit_deep_portails_2026_04_29` (memory). P0-3 (AuthCallback CSRF) reclassified as false positive — see analysis at the bottom.

## Changes

### 1. `.github/workflows/ci.yml` — unblock CI

Workflow still referenced the pre-split mono-repo layout : `cd portal && npm ci`, `cache-dependency-path: portal/package-lock.json`, plus a bogus `backend` Python job. Since the 2026-04-25 Rename & Reseed, this repo IS the portal: \`package.json\` + \`pnpm-lock.yaml\` at root, no Python.

**New workflow (single \`frontend\` job):**

\`\`\`yaml
- pnpm/action-setup@v4 (version: 10)
- actions/setup-node@v4 (node 20, cache: pnpm)
- pnpm install --frozen-lockfile
- pnpm exec tsc --noEmit
- pnpm test
- pnpm build
\`\`\`

\`pnpm lint\` step deliberately skipped — 174 pre-existing eslint errors (P2 in the audit). \`TODO\` comment in the workflow tracks it. Re-enable in a separate cleanup PR.

### 2. \`src/styles/tokens.css\` — fix orphan import

Removed:
\`\`\`css
@import \"../../../design-system/tokens.css\";
\`\`\`

This pointed two directories above the repo root (\`design-system/\` was a sibling package in the pre-split mono-repo). After the split, the file is gone — vite build crashed on \`Can't resolve '../../../design-system/tokens.css'\`.

The tokens it was supposed to bring in (\`--gp-text-label-*\`, \`--gp-spacing-*\`, \`--gp-width-*\`) are **already defined directly in \`src/index.css:84-98\`** since the split. The import was both dead (those tokens already resolve) and breaking the build. Updated the file comment to reflect the new single-source-of-truth.

## Smoke test

\`\`\`bash
pnpm install --frozen-lockfile
pnpm exec tsc --noEmit   # 0 errors
pnpm test                # 14 files, 126 tests passed (1.77s)
pnpm build               # built in 685ms
\`\`\`

## P0-3 (AuthCallbackPage CSRF) — reclassified false positive

The audit flagged \`gispulse-portal-pro/src/pages/auth/AuthCallbackPage.tsx\` for missing CSRF \`state\` validation. After reading both sides:

**Frontend (this repo / portal-pro)** — \`AuthCallbackPage\` does **NOT** read any URL params (no \`?next=\`, no \`?state=\`), it just calls \`fetchMe()\` and \`navigate(\"/\", { replace: true })\` (hardcoded). No open redirect surface.

**Backend (\`gispulse-enterprise\` src/.../routers/auth_router.py:109-156)** — does the OIDC CSRF check correctly :

\`\`\`python
state = secrets.token_urlsafe(32)               # cryptographic random
response.set_cookie(\"gispulse_oidc_state\", state, ...)  # HttpOnly
# ... user comes back via OIDC ...
stored_state = request.cookies.get(\"gispulse_oidc_state\")
if not stored_state or not secrets.compare_digest(stored_state, state):
    raise HTTPException(status_code=400, detail=\"Invalid state parameter (CSRF check failed)\")
\`\`\`

That is the correct scope for OIDC state validation — backend OIDC handler, timing-safe compare, HttpOnly cookie. The frontend landing page only sees the post-validation session cookie.

Net : nothing to change here. The audit memo will be updated to mark P0-3 as a false positive.

## Out of scope

- 174 eslint errors (P2). Separate cleanup PR.
- WIP changes in \`src/api/marketplace.ts\` and \`src/stores/authStore.ts\` that were on the working tree at the start of this session — left untouched, will land via their own commits.
- Other P1/P2 audit findings (i18n EN-only, lucide-react bump, raw API key in React state, etc.) — separate \"harden enterprise\" sprint per the audit's recommendation.