### PR TITLE
chore: P1 quickwins — publishConfig public + dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+version: 2
+
+updates:
+  # npm packages — pnpm-managed, weekly bump on Mondays
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+    labels:
+      - dependencies
+      - npm
+    groups:
+      # Group all minor/patch bumps to keep PR noise down
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
+      # Major bumps stay individual so they get reviewed properly
+      react-ecosystem:
+        applies-to: version-updates
+        patterns:
+          - react
+          - react-dom
+          - "@types/react*"
+          - react-router*
+        update-types:
+          - major
+      build-tooling:
+        applies-to: version-updates
+        patterns:
+          - vite*
+          - "@vitejs/*"
+          - typescript
+          - eslint*
+          - "@typescript-eslint/*"
+        update-types:
+          - major
+
+  # GitHub Actions — keep workflow versions current
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Paris
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - github-actions

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "GISPulse Portal — open-source web UI (AGPL-3.0). The Pro pages (admin, billing, SSO callback) live in the private @gispulse/portal-pro package.",
   "license": "AGPL-3.0-or-later",
   "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "dev": "vite",
     "build": "vite build",


### PR DESCRIPTION
Two safety/maintenance quick-wins from \`audit_deep_portails_2026_04_29\` (memory). Both are non-functional, low-risk additions that close audit P1 items #11 and #12.

## Changes

### 1. \`package.json\` — explicit \`publishConfig.access: public\`

\`\`\`diff
   \"license\": \"AGPL-3.0-or-later\",
   \"type\": \"module\",
+  \"publishConfig\": {
+    \"access\": \"public\"
+  },
   \"scripts\": {
\`\`\`

Scoped npm packages (\`@gispulse/portal-libre\`) default to \`restricted\` access. A stray \`pnpm publish\` from a contributor's machine would fail with a confusing \`402 Payment Required\` instead of just shipping the package. Making the AGPL public-publish intent explicit eliminates the surprise.

The audit suggested \`private: true\` — that's incorrect for this package since we DO want to publish it as the public OSS portal. \`publishConfig.access\` is the right fix.

### 2. \`.github/dependabot.yml\` — weekly npm + github-actions

Grouped strategy to keep PR volume sane:

- **Minor/patch updates** for all npm deps grouped into a single weekly PR.
- **React ecosystem majors** (\`react\`, \`react-dom\`, \`@types/react*\`, \`react-router*\`) kept individual — those need careful review.
- **Build tooling majors** (\`vite\`, \`@vitejs/*\`, \`typescript\`, \`eslint*\`) kept individual.
- **GitHub Actions** weekly updates, separate group.

Schedule: Monday 06:00 Europe/Paris, max 5 npm + 3 actions PRs open at once.

Same config can be ported to \`gispulse-portal-pro\` and \`gispulse-enterprise\` in follow-up PRs.

## Test plan

- [x] \`package.json\` valid JSON (verified with \`jq\`).
- [x] \`.github/dependabot.yml\` valid YAML.
- [ ] CI green on this PR.
- [ ] First dependabot run (next Monday after merge) opens reasonable batch of PRs.

## Out of scope (audit P1s left for separate PRs)

- **#5 Raw API key in React state** (\`ApiKeysPage.tsx:248\`) — lives in \`gispulse-portal-pro\`, separate repo.
- **#6 PII adminStore cleanup** (\`adminStore.ts:31-32\`) — same.
- **#7 0 tests portal-pro** — same, full sprint scope.
- **#8 Tests métier portal-libre** (NodePropertyPanel 860 LOC) — full sprint scope.
- **#9 i18n UI EN-only** — needs framework choice (react-i18next vs others).
- **#10 lucide-react ^1.7 → 1.14** — let the first dependabot run handle it.
- **174 eslint errors (P2)** — separate cleanup PR before re-enabling \`pnpm lint\` in CI.