### PR TITLE
fix(docker): add HEALTHCHECK + /healthz endpoint for portal container

### DIFF
--- a/Dockerfile.portal
+++ b/Dockerfile.portal
@@ -17,4 +17,10 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 
+# Liveness probe — `/healthz` is served directly by nginx (no proxy hop)
+# so this stays green even when the backend gispulse-api is down. Use
+# this for orchestrator (compose / k8s / ECS) liveness checks.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -q --spider http://127.0.0.1/healthz || exit 1
+
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -43,6 +43,16 @@ server {
         proxy_read_timeout 86400s;
     }
 
+    # Liveness probe — answers Docker HEALTHCHECK + orchestrator probes
+    # without proxying to the backend. Stays green even when gispulse-api
+    # is down. Returns 204 + an explicit `Cache-Control: no-cache` so
+    # health pings never get cached.
+    location = /healthz {
+        access_log off;
+        add_header Cache-Control "no-cache" always;
+        return 204;
+    }
+
     # SPA fallback: serve index.html for all non-file routes
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Closes the only Dockerfile-side P2 from \`audit_deep_portails_2026_04_29\`: \"Dockerfile.portal : pas de HEALTHCHECK\".

## Changes

### \`Dockerfile.portal\` — add \`HEALTHCHECK\` directive

\`\`\`dockerfile
HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \\
    CMD wget -q --spider http://127.0.0.1/healthz || exit 1
\`\`\`

\`wget\` is part of nginx:alpine's BusyBox by default — no extra install. Probe runs every 30s with 3s timeout and 5s startup grace period. After 3 consecutive failures the container is marked unhealthy.

### \`nginx.conf\` — explicit \`/healthz\` location

\`\`\`nginx
location = /healthz {
    access_log off;
    add_header Cache-Control \"no-cache\" always;
    return 204;
}
\`\`\`

Three subtle but important choices:

- **Returns 204 No Content directly from nginx** — does NOT proxy to \`gispulse-api\`, so the probe stays green when the backend is down. That's intentional: this is **liveness** (nginx itself running and serving), not **readiness** (full stack). Use \`/\` for readiness if you want to gate traffic on the SPA assets being served.
- **\`access_log off\`** — keeps the probe out of the request log so the log isn't drowned by 2 hits/min × N replicas.
- **\`Cache-Control: no-cache\`** — defensive against intermediaries (CDNs, debug proxies) that might cache 204 responses.

## Why this matters

Currently \`docker compose up\` shows the portal as \`healthy\` immediately because there's no probe — even if nginx crashed silently. Same for k8s liveness/readiness probes : without a HEALTHCHECK in the image, k8s defaults to TCP port-open which doesn't catch \"nginx running but mis-configured\". This PR makes the container honest about its state.

## Test plan

\`\`\`bash
docker build -f Dockerfile.portal -t portal-libre:healthcheck-test .
docker run -d --name probe-test -p 8080:80 portal-libre:healthcheck-test

# Wait ~10s past the start-period
sleep 10
docker inspect --format '{{json .State.Health}}' probe-test | jq
# Expected: {\"Status\": \"healthy\", ...}

curl -i http://127.0.0.1:8080/healthz
# Expected: HTTP/1.1 204 No Content + Cache-Control: no-cache

# Verify it survives backend being unreachable
docker run --rm -d --name no-backend -p 8081:80 portal-libre:healthcheck-test
sleep 10
docker inspect --format '{{json .State.Health}}' no-backend | jq .Status
# Expected: \"healthy\" (nginx alive, /healthz green even with no backend)
\`\`\`

## Out of scope

- Backend container HEALTHCHECK (\`gispulse-api\` already has one in the engine repo).
- Readiness probe (orchestrator-specific concern).
- nginx CSP refresh — separate audit follow-up.
- npm→pnpm conversion — already done in a prior commit (corepack + pnpm@9 in this Dockerfile since 2026-04-29).