### PR TITLE
feat(i18n): central useT() hook + bilingual STRINGS dictionary (PoC)

### DIFF
--- a/src/components/nodes/NodePropertyPanel.tsx
+++ b/src/components/nodes/NodePropertyPanel.tsx
@@ -24,6 +24,7 @@ import { SchemaForm } from "./SchemaForm"
 import { isRenderableSchema, validateAgainstSchema, type JSONSchema } from "./schemaFormUtils"
 import { useCapabilities } from "@/hooks/useCapabilities"
 import { useLocaleStore } from "@/stores/localeStore"
+import { useT } from "@/i18n/useT"
 import { makeCapabilityTranslator } from "@/i18n/capabilityLabels"
 
 // ---------------------------------------------------------------------------
@@ -124,6 +125,7 @@ export function NodePropertyPanel({ nodeId, nodeType, nodeData }: NodePropertyPa
   const { caps, byName, loading: capsLoading } = useCapabilities()
   const locale = useLocaleStore((s) => s.locale)
   const toggleLocale = useLocaleStore((s) => s.toggleLocale)
+  const t = useT()
 
   const data = nodeData ?? {}
   const label = (data.label as string) ?? "Node"
@@ -418,13 +420,13 @@ export function NodePropertyPanel({ nodeId, nodeType, nodeData }: NodePropertyPa
                 <>
                   <div className="flex items-center justify-between mt-3 mb-1.5">
                     <h4 className="text-label font-semibold uppercase tracking-wider text-muted-foreground">
-                      {locale === "fr" ? "Paramètres" : "Parameters"}
+                      {t("node.properties.parameters_heading")}
                     </h4>
                     <button
                       type="button"
                       onClick={toggleLocale}
                       className="text-label-sm text-muted-foreground hover:text-foreground hover:underline"
-                      aria-label={locale === "fr" ? "Switch to English labels" : "Passer en français"}
+                      aria-label={t("locale.toggle.tooltip")}
                       title={locale === "fr" ? "EN" : "FR"}
                     >
                       {locale === "fr" ? "EN" : "FR"}

--- a/src/i18n/__tests__/useT.test.ts
+++ b/src/i18n/__tests__/useT.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, beforeEach } from "vitest"
+
+import { useLocaleStore } from "@/stores/localeStore"
+import { translate } from "../useT"
+import type { StringKey } from "../strings"
+
+describe("translate (locale-agnostic)", () => {
+  it("returns the EN variant in EN locale", () => {
+    expect(translate("common.cancel", "en")).toBe("Cancel")
+    expect(translate("common.save", "en")).toBe("Save")
+  })
+
+  it("returns the FR variant in FR locale", () => {
+    expect(translate("common.cancel", "fr")).toBe("Annuler")
+    expect(translate("common.save", "fr")).toBe("Enregistrer")
+  })
+
+  it("falls back to the key when the entry is unknown", () => {
+    // @ts-expect-error — testing the unknown-key fallback path
+    expect(translate("nonexistent.key", "en")).toBe("nonexistent.key")
+  })
+
+  it("covers every advertised namespace", () => {
+    // Smoke check — keys exist in every namespace we documented.
+    const required: StringKey[] = [
+      "common.cancel",
+      "locale.toggle.tooltip",
+      "dialog.unsaved.title",
+      "toast.saved",
+      "error.network",
+    ]
+    for (const key of required) {
+      expect(translate(key, "en")).toBeTruthy()
+      expect(translate(key, "fr")).toBeTruthy()
+    }
+  })
+})
+
+describe("useT integration with localeStore", () => {
+  beforeEach(() => {
+    // Reset to EN before each test so the store doesn't leak state.
+    useLocaleStore.getState().setLocale("en")
+  })
+
+  it("translate matches the active locale", () => {
+    useLocaleStore.getState().setLocale("fr")
+    expect(translate("common.delete", useLocaleStore.getState().locale)).toBe("Supprimer")
+
+    useLocaleStore.getState().setLocale("en")
+    expect(translate("common.delete", useLocaleStore.getState().locale)).toBe("Delete")
+  })
+})

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -1,0 +1,77 @@
+/**
+ * strings.ts — Central UI string dictionary, FR/EN.
+ *
+ * Pattern: each entry is a `Bilingual` record. Lookups go through
+ * the `useT()` hook (see `i18n/useT.ts`) which reads the active
+ * locale from `localeStore` and returns the right variant.
+ *
+ * Conventions:
+ * - Namespaces are dot-separated: "namespace.key" (`common.cancel`).
+ * - Keep entries flat — nested objects make grep/IDE-search painful.
+ * - One namespace per UI domain (`common`, `dialog`, `toast`, `error`,
+ *   `node`, `trigger`, …). Add as needed.
+ * - Capability-specific labels live in `capabilityLabels.ts` (separate
+ *   indexing strategy, schema-driven). Don't duplicate them here.
+ *
+ * Migration policy: when you hardcode a string in EN inside a `.tsx`
+ * file, add the entry here and switch to `t("namespace.key")`. No need
+ * to migrate everything at once — incremental is fine.
+ */
+
+export type Bilingual = { en: string; fr: string }
+
+export const STRINGS = {
+  // ─── Buttons / actions used across the app ────────────────────────────────
+  "common.cancel": { en: "Cancel", fr: "Annuler" },
+  "common.confirm": { en: "Confirm", fr: "Confirmer" },
+  "common.save": { en: "Save", fr: "Enregistrer" },
+  "common.delete": { en: "Delete", fr: "Supprimer" },
+  "common.edit": { en: "Edit", fr: "Éditer" },
+  "common.close": { en: "Close", fr: "Fermer" },
+  "common.retry": { en: "Retry", fr: "Réessayer" },
+  "common.loading": { en: "Loading…", fr: "Chargement…" },
+  "common.empty": { en: "No data", fr: "Aucune donnée" },
+  "common.search": { en: "Search", fr: "Rechercher" },
+  "common.copy": { en: "Copy", fr: "Copier" },
+  "common.copied": { en: "Copied", fr: "Copié" },
+
+  // ─── Locale toggle (the button itself) ────────────────────────────────────
+  "locale.toggle.tooltip": {
+    en: "Switch interface language",
+    fr: "Changer la langue de l'interface",
+  },
+  "locale.toggle.label_en": { en: "EN", fr: "EN" },
+  "locale.toggle.label_fr": { en: "FR", fr: "FR" },
+
+  // ─── Generic dialog scaffolding ───────────────────────────────────────────
+  "dialog.unsaved.title": { en: "Unsaved changes", fr: "Modifications non enregistrées" },
+  "dialog.unsaved.body": {
+    en: "You have unsaved changes. Discard them?",
+    fr: "Vous avez des modifications non enregistrées. Les abandonner ?",
+  },
+  "dialog.unsaved.discard": { en: "Discard", fr: "Abandonner" },
+
+  // ─── Toasts (success path) ────────────────────────────────────────────────
+  "toast.saved": { en: "Saved", fr: "Enregistré" },
+  "toast.copied_clipboard": { en: "Copied to clipboard", fr: "Copié dans le presse-papiers" },
+  "toast.deleted": { en: "Deleted", fr: "Supprimé" },
+
+  // ─── Node property panel ──────────────────────────────────────────────────
+  "node.properties.parameters_heading": { en: "Parameters", fr: "Paramètres" },
+
+  // ─── Error messages (user-facing) ─────────────────────────────────────────
+  "error.network": {
+    en: "Network error. Check your connection and retry.",
+    fr: "Erreur réseau. Vérifiez votre connexion et réessayez.",
+  },
+  "error.unauthorized": {
+    en: "Session expired. Sign in again.",
+    fr: "Session expirée. Reconnectez-vous.",
+  },
+  "error.unknown": {
+    en: "Something went wrong. Please retry.",
+    fr: "Une erreur est survenue. Veuillez réessayer.",
+  },
+} as const satisfies Record<string, Bilingual>
+
+export type StringKey = keyof typeof STRINGS

--- a/src/i18n/useT.ts
+++ b/src/i18n/useT.ts
@@ -1,0 +1,53 @@
+/**
+ * useT — bilingual string lookup hook.
+ *
+ *   const t = useT()
+ *   <button>{t("common.cancel")}</button>
+ *
+ * The hook reads the active locale from `localeStore` and returns a
+ * stable function that walks `STRINGS` for the requested key. Unknown
+ * keys (typos, deleted entries, mid-rebase) fall back to the key itself
+ * so the UI never blanks out — easy to spot in QA.
+ *
+ * For dynamic interpolation, wrap the result :
+ *
+ *   const t = useT()
+ *   const msg = t("dataset.upload.progress").replace("{n}", String(count))
+ *
+ * (Yes, pure-string interpolation. We deliberately don't ship ICU /
+ * MessageFormat here — the bespoke pattern stays simple. If we ever
+ * need plural rules across locales, the `localeStore` already exposes
+ * `Intl.PluralRules(locale)` indirectly via `navigator.language`.)
+ */
+
+import { useCallback } from "react"
+
+import { useLocaleStore } from "@/stores/localeStore"
+import { STRINGS, type StringKey } from "./strings"
+
+export function useT(): (key: StringKey) => string {
+  const locale = useLocaleStore((s) => s.locale)
+  return useCallback(
+    (key: StringKey): string => {
+      const entry = STRINGS[key]
+      if (!entry) {
+        // Unknown key — return the key itself so QA can grep for it
+        // without the UI blanking out. Not throwing so a missing
+        // mid-rebase string never breaks the page.
+        return key
+      }
+      return entry[locale] ?? entry.en
+    },
+    [locale],
+  )
+}
+
+/**
+ * Locale-agnostic variant for unit tests / non-React callers. Pass the
+ * locale explicitly. Same fallback rules as `useT()`.
+ */
+export function translate(key: StringKey, locale: "en" | "fr"): string {
+  const entry = STRINGS[key]
+  if (!entry) return key
+  return entry[locale] ?? entry.en
+}


### PR DESCRIPTION
First step on issue #4 (\"i18n: extract UI strings to FR/EN dictionaries\"). The project already has a bespoke bilingual pattern (\`localeStore\` + \`Bilingual\` records in \`i18n/capabilityLabels.ts\`), so this PR **extends** it rather than introducing react-i18next as a parallel framework.

## What's added

### \`src/i18n/strings.ts\` — central UI string dictionary

Namespaced by domain (\`common.*\`, \`dialog.*\`, \`toast.*\`, \`error.*\`, \`locale.*\`, \`node.*\`). Flat keys by design — nested objects make grep/IDE-search painful at this scale. Capability-specific labels stay in \`capabilityLabels.ts\` (separate schema-driven indexing).

Starter set (~25 entries) covers the recurring buttons + dialog scaffolding + toasts + error messages most components need :

\`\`\`ts
\"common.cancel\": { en: \"Cancel\", fr: \"Annuler\" },
\"common.save\": { en: \"Save\", fr: \"Enregistrer\" },
\"dialog.unsaved.title\": { en: \"Unsaved changes\", fr: \"Modifications non enregistrées\" },
\"toast.copied_clipboard\": { en: \"Copied to clipboard\", fr: \"Copié dans le presse-papiers\" },
\"error.network\": { en: \"Network error. Check your connection and retry.\", fr: \"Erreur réseau. Vérifiez votre connexion et réessayez.\" },
// …
\`\`\`

### \`src/i18n/useT.ts\` — the hook

\`\`\`ts
const t = useT()
<button>{t(\"common.cancel\")}</button>
\`\`\`

Returns a stable \`(key: StringKey) => string\` callback that reads the active locale from \`localeStore\`. Unknown keys fall back to the key itself so mid-rebase / typo'd keys don't blank out the UI — they're easy to grep in QA.

Locale-agnostic \`translate(key, locale)\` exported for unit tests / non-React callers.

### \`src/i18n/__tests__/useT.test.ts\` — 5 cases

EN/FR variants, unknown-key fallback, namespace coverage smoke test, \`localeStore\` integration.

### PoC migration in \`NodePropertyPanel.tsx\` (line 421-431)

\`\`\`diff
-  {locale === \"fr\" ? \"Paramètres\" : \"Parameters\"}
+  {t(\"node.properties.parameters_heading\")}
-  aria-label={locale === \"fr\" ? \"Switch to English labels\" : \"Passer en français\"}
+  aria-label={t(\"locale.toggle.tooltip\")}
\`\`\`

Two strings migrated to demonstrate the pattern.

## Why bespoke and not react-i18next

- The codebase already uses \`Bilingual\` records (\`{ en, fr }\`) and reads from \`localeStore\` — a parallel react-i18next setup would create two systems competing for the same domain.
- No need for ICU / MessageFormat / pluralization yet (only 2 locales, no count-aware messages).
- Bundle size : zero new deps.
- Type safety : \`StringKey\` is auto-inferred from \`STRINGS\`, so \`t(\"common.cnacel\")\` is a TS error at write time.

## Migration policy

In \`strings.ts\` doc comment :

> When you hardcode a string in EN inside a \`.tsx\` file, add the entry to \`STRINGS\` and switch to \`t(\"namespace.key\")\`. No need to migrate everything at once — incremental is fine.

The \`locale === \"fr\" ? ... : ...\` ternaries elsewhere in the codebase keep working until each component is touched.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` — clean.
- [x] \`pnpm test\` — 131 passed (126 baseline + 5 new).
- [x] \`pnpm build\` — built in 753 ms, no new chunk size warning.
- [ ] CI green.

## Out of scope

- Migration of the rest of \`NodePropertyPanel.tsx\`'s ~860 LOC of ternaries — incremental.
- Dialog / toast / error string migrations across the app — incremental per component as touched.
- ICU / MessageFormat support — bespoke pattern stays simple.
- A standalone \`LocaleToggle\` component — toggle stays inline in the node panel for now.
- Locale-aware date / number formatting — \`Intl\` direct usage is fine.

Closes none — issue #4 stays open as the rolling tracker for incremental migration.