### PR TITLE
test(triggers): cover constants.ts taxonomies + helpers

### DIFF
--- a/src/components/triggers/__tests__/constants.test.ts
+++ b/src/components/triggers/__tests__/constants.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Unit tests for `triggers/constants.ts` — taxonomy invariants and helpers.
+ *
+ * Why this matters: `constants.ts` is the single source of truth for the
+ * Trigger Builder UI's option lists (DML events, threshold ops, validation
+ * rules, action types, spatial ops). Drift between this file and the
+ * `editor.ts` types — or accidental duplicates / orphans — surfaces as
+ * silent rendering bugs ("disabled action stays clickable", "category icon
+ * missing"). The runtime checks here catch the drift at build time.
+ */
+
+import { describe, expect, it } from "vitest"
+
+import {
+  ACTION_TYPES,
+  CATEGORY_ICONS,
+  DML_EVENTS,
+  SEVERITY_LEVELS,
+  SPATIAL_OPS_AFTER,
+  SPATIAL_OPS_BEFORE,
+  THRESHOLD_OPS,
+  TOPOLOGY_CHECKS,
+  TRIGGER_CATEGORIES,
+  TRIGGER_TYPES,
+  VALIDATION_RULES,
+  categoryForType,
+  emptyOperation,
+} from "../constants"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+describe("emptyOperation", () => {
+  it("returns a TriggerOperation with sane defaults", () => {
+    const op = emptyOperation()
+    expect(op.schema).toBe("")
+    expect(op.table).toBe("")
+    expect(op.field).toBe("")
+    expect(op.phase).toBe("before")
+    expect(op.operation).toBe("st_within")
+    expect(op.event).toBe("INSERT,UPDATE")
+    expect(op.enabled).toBe(true)
+  })
+
+  it("returns a fresh instance each call (no shared mutable state)", () => {
+    const a = emptyOperation()
+    const b = emptyOperation()
+    expect(a).not.toBe(b) // distinct references
+    a.table = "mutated"
+    expect(b.table).toBe("") // mutation does not leak
+  })
+})
+
+describe("categoryForType", () => {
+  it("returns the correct category for each declared TRIGGER_TYPES entry", () => {
+    for (const tt of TRIGGER_TYPES) {
+      expect(categoryForType(tt.value)).toBe(tt.category)
+    }
+  })
+
+  it("falls back to 'data' for unknown trigger types", () => {
+    // @ts-expect-error — testing the unknown-type fallback path
+    expect(categoryForType("not_a_real_type")).toBe("data")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Taxonomy invariants — drift detectors
+// ---------------------------------------------------------------------------
+
+describe("TRIGGER_TYPES taxonomy", () => {
+  it("has unique values (no duplicate trigger keys)", () => {
+    const values = TRIGGER_TYPES.map((t) => t.value)
+    expect(new Set(values).size).toBe(values.length)
+  })
+
+  it("references valid categories declared in TRIGGER_CATEGORIES", () => {
+    const validCategories = new Set(TRIGGER_CATEGORIES.map((c) => c.value))
+    for (const tt of TRIGGER_TYPES) {
+      expect(validCategories).toContain(tt.category)
+    }
+  })
+
+  it("provides every required field (label, icon, description)", () => {
+    for (const tt of TRIGGER_TYPES) {
+      expect(tt.label.length).toBeGreaterThan(0)
+      expect(tt.icon).toBeTruthy()
+      expect(tt.description.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("TRIGGER_CATEGORIES taxonomy", () => {
+  it("has unique values", () => {
+    const values = TRIGGER_CATEGORIES.map((c) => c.value)
+    expect(new Set(values).size).toBe(values.length)
+  })
+
+  it("matches CATEGORY_ICONS keys exactly (no orphan icons, no missing icons)", () => {
+    const categoryValues = new Set(TRIGGER_CATEGORIES.map((c) => c.value))
+    const iconKeys = new Set(Object.keys(CATEGORY_ICONS))
+    expect(iconKeys).toEqual(categoryValues)
+  })
+})
+
+describe("CATEGORY_ICONS — every TRIGGER_TYPES.category resolves to an icon", () => {
+  it("never produces an undefined icon lookup", () => {
+    for (const tt of TRIGGER_TYPES) {
+      const icon = CATEGORY_ICONS[tt.category]
+      expect(icon).toBeTruthy()
+    }
+  })
+})
+
+describe("ACTION_TYPES", () => {
+  it("has unique action values", () => {
+    const values = ACTION_TYPES.map((a) => a.value)
+    expect(new Set(values).size).toBe(values.length)
+  })
+
+  it("disabled actions all have a 'coming soon' label hint", () => {
+    // Convention: any action with `disabled: true` should signal the
+    // upcoming nature so the user understands why it's greyed out.
+    for (const a of ACTION_TYPES) {
+      if (a.disabled) {
+        expect(a.label.toLowerCase()).toContain("coming soon")
+      }
+    }
+  })
+
+  it("groups actions into known categories", () => {
+    const knownCategories = new Set([
+      "notification",
+      "mutation",
+      "execution",
+      "workflow",
+      "external",
+    ])
+    for (const a of ACTION_TYPES) {
+      expect(knownCategories).toContain(a.category)
+    }
+  })
+})
+
+describe("DML_EVENTS", () => {
+  it("contains exactly INSERT, UPDATE, DELETE", () => {
+    expect(DML_EVENTS).toEqual(["INSERT", "UPDATE", "DELETE"])
+  })
+})
+
+describe("THRESHOLD_OPS / TOPOLOGY_CHECKS / VALIDATION_RULES — uniqueness", () => {
+  it.each([
+    ["THRESHOLD_OPS", THRESHOLD_OPS],
+    ["TOPOLOGY_CHECKS", TOPOLOGY_CHECKS],
+    ["VALIDATION_RULES", VALIDATION_RULES],
+  ])("%s has unique values", (_name, list) => {
+    const values = (list as { value: string }[]).map((x) => x.value)
+    expect(new Set(values).size).toBe(values.length)
+  })
+})
+
+describe("SEVERITY_LEVELS", () => {
+  it("ordered from least to most severe (info → critical)", () => {
+    const order = SEVERITY_LEVELS.map((s) => s.value)
+    expect(order).toEqual(["info", "warning", "error", "critical"])
+  })
+
+  it("each level has icon + tailwind text/bg color classes", () => {
+    for (const lvl of SEVERITY_LEVELS) {
+      expect(lvl.icon).toBeTruthy()
+      expect(lvl.color).toMatch(/^text-/)
+      expect(lvl.bg).toMatch(/^bg-/)
+    }
+  })
+})
+
+describe("SPATIAL_OPS — phase split", () => {
+  it("BEFORE and AFTER both have non-empty operation lists", () => {
+    expect(SPATIAL_OPS_BEFORE.length).toBeGreaterThan(0)
+    expect(SPATIAL_OPS_AFTER.length).toBeGreaterThan(0)
+  })
+
+  it("each operation entry has label + description", () => {
+    for (const op of [...SPATIAL_OPS_BEFORE, ...SPATIAL_OPS_AFTER]) {
+      expect(op.label.length).toBeGreaterThan(0)
+      expect(op.description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("custom_expression is offered in both phases (escape hatch)", () => {
+    expect(SPATIAL_OPS_BEFORE.some((o) => o.value === "custom_expression")).toBe(true)
+    expect(SPATIAL_OPS_AFTER.some((o) => o.value === "custom_expression")).toBe(true)
+  })
+})


### PR DESCRIPTION
First dent in audit P1 #8 (\"Tests métier manquants portal-libre\", issue #3) — start with the Trigger Builder taxonomy module since it's pure-data, no React/zustand mocking required.

## What's tested

\`\`\`
src/components/triggers/__tests__/constants.test.ts — 22 cases
\`\`\`

### Helpers
- **\`emptyOperation()\`** — sane defaults + no shared mutable state across calls.
- **\`categoryForType()\`** — direct lookup over every TRIGGER_TYPES entry + 'data' fallback for unknown types (TS error on the unknown call site is intentional).

### Taxonomy invariants — drift detectors

These are the tests that catch silent rendering bugs at build time when someone adds a new TriggerType to the union without updating the constants table, or vice versa :

- **TRIGGER_TYPES** — value uniqueness, every \`category\` field references a value declared in TRIGGER_CATEGORIES, every entry has label + icon + description.
- **TRIGGER_CATEGORIES** — value uniqueness, **CATEGORY_ICONS keys match TRIGGER_CATEGORIES values exactly** (no orphan icons, no missing icons).
- **CATEGORY_ICONS** — every \`TRIGGER_TYPES.category\` resolves to a non-undefined icon at lookup time.
- **ACTION_TYPES** — value uniqueness, disabled actions all have a \"coming soon\" label hint, every entry has a category in the known set (notification / mutation / execution / workflow / external).
- **DML_EVENTS** — exact set \`[\"INSERT\", \"UPDATE\", \"DELETE\"]\` (would catch accidental \"TRUNCATE\" / \"MERGE\" additions).
- **THRESHOLD_OPS / TOPOLOGY_CHECKS / VALIDATION_RULES** — uniqueness across each list (table-driven test with \`it.each\`).
- **SEVERITY_LEVELS** — ordering invariant (info → warning → error → critical), each level has icon + tailwind \`text-*\` color + \`bg-*\` color classes.
- **SPATIAL_OPS_BEFORE / SPATIAL_OPS_AFTER** — both non-empty, each entry has label + description, \`custom_expression\` is offered in both phases (escape hatch).

### Why drift tests matter

\`constants.ts\` is the single source of truth for the Trigger Builder UI dropdowns. Drift between this file and the \`editor.ts\` type union surfaces as silent rendering bugs in production : \"disabled action stays clickable\", \"category icon missing\", \"unknown trigger type renders as 'data'\". Build-time tests catch the drift early.

## Test plan

- [x] \`pnpm test src/components/triggers/__tests__/constants.test.ts\` — 22 passed in 534 ms.
- [x] \`pnpm test\` (full) — 153 passed (131 prior + 22 new).
- [x] \`pnpm exec tsc --noEmit\` — clean.

## Out of scope (separate PRs)

- **TriggerBuilderInline / Modal component render tests** — needs zustand + react-query mock infra setup first; doable but heavier.
- **PredicateBuilder \`describeAggregation\` / \`isAggregationPredicate\`** — currently file-private helpers, would need exporting first. Worth doing in a follow-up since they're pure functions with non-trivial logic.
- **NodePropertyPanel test battery** — the 860-LOC component flagged in the audit; full sprint scope, needs the same mock infra.
- **CronBuilder** — same shape, same testability profile as PredicateBuilder.

## Strategy note

Issue #3 stays open as the rolling tracker. This PR is one slice of it — constants only. The \"hard\" components (NodePropertyPanel, TriggerBuilderInline) need test infrastructure decisions (which to mock, fixture pattern, render wrapper) that are worth one focused decision PR before piling on test files.