### PR TITLE
test(triggers): cover CronBuilder component (presets + fields + preview)

### DIFF
--- a/src/components/triggers/__tests__/CronBuilder.test.tsx
+++ b/src/components/triggers/__tests__/CronBuilder.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Component tests for CronBuilder — exercises both the pure parse/build
+ * cron logic and the React rendering surface. Pattern mirrors the
+ * existing SchemaForm.test.tsx (testing-library/react + vitest, no
+ * zustand mocking required because CronBuilder is fully prop-driven).
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { CronBuilder } from "../CronBuilder"
+
+function harness(initial = "0 * * * *") {
+  const onChange = vi.fn<(cron: string) => void>()
+  const view = render(<CronBuilder value={initial} onChange={onChange} />)
+  return { onChange, ...view }
+}
+
+describe("CronBuilder — presets", () => {
+  it("renders the four preset buttons", () => {
+    harness()
+    expect(screen.getByRole("button", { name: /every 15 min/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /every hour/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /every day midnight/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /every monday 8am/i })).toBeInTheDocument()
+  })
+
+  it("emits the preset cron string on click", () => {
+    const { onChange } = harness("")
+    fireEvent.click(screen.getByRole("button", { name: /every 15 min/i }))
+    expect(onChange).toHaveBeenLastCalledWith("*/15 * * * *")
+
+    fireEvent.click(screen.getByRole("button", { name: /every monday 8am/i }))
+    expect(onChange).toHaveBeenLastCalledWith("0 8 * * 1")
+  })
+
+  it("highlights the active preset when value matches", () => {
+    harness("0 0 * * *")
+    const button = screen.getByRole("button", { name: /every day midnight/i })
+    // The active preset gets the `border-primary` class; non-active rows
+    // get `border-border`. We assert on the class to avoid hardcoding the
+    // exact tailwind string.
+    expect(button.className).toContain("border-primary")
+  })
+})
+
+describe("CronBuilder — granular fields", () => {
+  it("renders 5 labeled inputs (Min / Hour / Day / Month / Weekday)", () => {
+    harness()
+    expect(screen.getByLabelText("Min")).toBeInTheDocument()
+    expect(screen.getByLabelText("Hour")).toBeInTheDocument()
+    expect(screen.getByLabelText("Day")).toBeInTheDocument()
+    expect(screen.getByLabelText("Month")).toBeInTheDocument()
+    expect(screen.getByLabelText("Weekday")).toBeInTheDocument()
+  })
+
+  it("populates inputs from the current cron value", () => {
+    harness("30 9 * * 1")
+    expect(screen.getByLabelText("Min")).toHaveValue("30")
+    expect(screen.getByLabelText("Hour")).toHaveValue("9")
+    expect(screen.getByLabelText("Day")).toHaveValue("*")
+    expect(screen.getByLabelText("Month")).toHaveValue("*")
+    expect(screen.getByLabelText("Weekday")).toHaveValue("1")
+  })
+
+  it("emits the rebuilt cron when a single field changes", () => {
+    const { onChange } = harness("0 8 * * *")
+    fireEvent.change(screen.getByLabelText("Hour"), { target: { value: "14" } })
+    expect(onChange).toHaveBeenLastCalledWith("0 14 * * *")
+  })
+
+  it("substitutes '*' when a field is cleared (empty string)", () => {
+    const { onChange } = harness("30 9 1 6 *")
+    fireEvent.change(screen.getByLabelText("Day"), { target: { value: "" } })
+    expect(onChange).toHaveBeenLastCalledWith("30 9 * 6 *")
+  })
+
+  it("preserves the other fields when only one changes", () => {
+    const { onChange } = harness("15 10 5 7 3")
+    fireEvent.change(screen.getByLabelText("Min"), { target: { value: "0" } })
+    expect(onChange).toHaveBeenLastCalledWith("0 10 5 7 3")
+  })
+})
+
+describe("CronBuilder — expression preview", () => {
+  it("shows the current value verbatim in the cron preview", () => {
+    harness("*/15 9-17 * * 1-5")
+    expect(screen.getByText("*/15 9-17 * * 1-5")).toBeInTheDocument()
+  })
+
+  it("falls back to '* * * * *' when value is empty", () => {
+    harness("")
+    expect(screen.getByText("* * * * *")).toBeInTheDocument()
+  })
+})
+
+describe("CronBuilder — parseCron edge cases (via component)", () => {
+  it("handles extra whitespace in input cron", () => {
+    harness("  0   9   *   *   *  ")
+    expect(screen.getByLabelText("Min")).toHaveValue("0")
+    expect(screen.getByLabelText("Hour")).toHaveValue("9")
+  })
+
+  it("defaults missing fields to '*' when cron is incomplete", () => {
+    // 3-field cron — last 2 default to *
+    harness("0 9 *")
+    expect(screen.getByLabelText("Min")).toHaveValue("0")
+    expect(screen.getByLabelText("Hour")).toHaveValue("9")
+    expect(screen.getByLabelText("Day")).toHaveValue("*")
+    expect(screen.getByLabelText("Month")).toHaveValue("*")
+    expect(screen.getByLabelText("Weekday")).toHaveValue("*")
+  })
+})


### PR DESCRIPTION
Second slice of audit P1 #8 (issue #3 — \"test: cover NodePropertyPanel + triggers + predicate builders\"). After PR #12 (\`constants.ts\` taxonomies, 22 cases), this adds 12 component-level cases for \`CronBuilder\`.

## Why CronBuilder is the right next step

It's the **most isolated** of the trigger sub-components :

- Fully prop-driven : \`value: string\` + \`onChange: (cron) => void\`.
- Zero zustand / react-query / router dependencies.
- No async, no toast, no mutation hooks.
- Tests follow the existing \`src/__tests__/SchemaForm.test.tsx\` pattern verbatim — no new mock infra needed.

The bigger trigger components (TriggerBuilderInline / Modal / NodePropertyPanel) need a one-shot infra decision (fixture pattern for zustand stores + react-query wrapper) before piling on test files. CronBuilder is the bite-size win that doesn't block on that decision.

## Coverage

12 cases across 4 surfaces :

### Presets (3 cases)
- 4 preset buttons render with the right labels.
- Clicking a preset emits the cron string verbatim (\`*/15 * * * *\`, \`0 8 * * 1\`).
- Active preset gets the \`border-primary\` class when \`value\` matches.

### Granular fields (5 cases)
- 5 labeled inputs render (\`Min\` / \`Hour\` / \`Day\` / \`Month\` / \`Weekday\`).
- Inputs populate from the current cron value (\`30 9 * * 1\` → respective fields).
- Changing one field emits the rebuilt cron with all five parts.
- Clearing a field (empty string) substitutes \`*\` — exercises the \`val || \"*\"\` fallback.
- Other fields are preserved when only one changes.

### Expression preview (2 cases)
- Current value displayed verbatim in the \`cron:\` \`<code>\` block.
- Empty value falls back to \`* * * * *\` display.

### parseCron edge cases via component (2 cases)
- Extra whitespace handled (regex split \`\\s+\`).
- Missing fields default to \`*\` (3-field cron → last 2 become wildcards).

## Test plan

- [x] \`pnpm test src/components/triggers/__tests__/CronBuilder.test.tsx\` — 12 passed in 626 ms.
- [x] \`pnpm test\` (full) — 138 passed (126 baseline + 12 new ; this branch is independent of PR #11 i18n PoC and PR #12 constants tests).
- [x] \`pnpm exec tsc --noEmit\` — clean.

## Out of scope (separate PRs)

- **ActionEditor** — 140 LOC, similar shape, may need a small fixture for the actions list. Easy follow-up.
- **PredicateBuilder** — 480 LOC, recursive AnyPredicate / CompoundPredicate / AttrPredicate / GeomPredicate cases. Worth its own PR with adequate complexity budget.
- **TriggerBuilderInline / Modal** — orchestrate ActionEditor + PredicateBuilder + CronBuilder. Best after the leaf components are covered.
- **NodePropertyPanel** — 860 LOC component with multi-store dependencies; needs the test infra decision first.

## Stacking

This PR stacks cleanly with #11 (i18n PoC) and #12 (constants tests) — they touch disjoint files. Merge order doesn't matter.