### PR TITLE
test(infra): renderWithProviders + setupStoreReset helpers + README

### DIFF
--- a/src/__tests__/helpers/README.md
+++ b/src/__tests__/helpers/README.md
@@ -1,0 +1,115 @@
+# Test helpers
+
+Composable utilities for component tests that need more than the default
+`render(ui)` from testing-library.
+
+## When to reach for which helper
+
+| Need | Helper |
+|---|---|
+| Component uses `useNavigate` / `<Link>` / `useLocation` | `renderWithProviders` with `routerEntries` |
+| Component uses zustand store(s) | `setupStoreReset(...stores)` in `describe` |
+| Component imports `toast` from `sonner` | `vi.mock("sonner", …)` at file top (see snippet below) |
+| Component calls `@/api/client` functions | `vi.mock("@/api/client", …)` at file top |
+| Component uses `useCapabilities` | `_resetCapabilitiesCacheForTests()` from the hook itself, plus a mock for `listCapabilities` if needed |
+
+## Patterns
+
+### Plain prop-driven component
+
+No helper needed. See `components/triggers/__tests__/CronBuilder.test.tsx` for the canonical small example.
+
+```tsx
+import { render, screen, fireEvent } from "@testing-library/react"
+import { describe, it, expect, vi } from "vitest"
+import { MyLeaf } from "../MyLeaf"
+
+it("renders", () => {
+  render(<MyLeaf value="x" onChange={vi.fn()} />)
+  expect(screen.getByDisplayValue("x")).toBeInTheDocument()
+})
+```
+
+### Component that uses react-router
+
+```tsx
+import { renderWithProviders } from "@/__tests__/helpers/renderWithProviders"
+
+it("navigates on submit", () => {
+  renderWithProviders(<MyForm />, { routerEntries: ["/projects/123"] })
+  // ...
+})
+```
+
+### Component that uses zustand stores
+
+```tsx
+import { describe, it, expect } from "vitest"
+import { useEditorStore } from "@/stores/editorStore"
+import { setupStoreReset } from "@/__tests__/helpers/zustand"
+
+describe("MyComponent", () => {
+  setupStoreReset(useEditorStore)
+
+  it("starts with no active scenario", () => {
+    expect(useEditorStore.getState().activeScenarioId).toBeNull()
+  })
+
+  it("reacts to state mutation", () => {
+    useEditorStore.setState({ activeScenarioId: "scn-1" })
+    render(<MyComponent />)
+    // assertions ...
+    // After this test, useEditorStore is auto-reset to its default state.
+  })
+})
+```
+
+### Component that uses `sonner` toast
+
+`vi.mock` calls are hoisted by Vitest, so they must live at the **top of the test file**, not inside a helper. Canonical snippet :
+
+```tsx
+import { vi } from "vitest"
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}))
+
+import { toast } from "sonner"  // import AFTER vi.mock so the mock takes effect
+
+// In tests :
+import { beforeEach } from "vitest"
+beforeEach(() => {
+  vi.mocked(toast.success).mockClear()
+  vi.mocked(toast.error).mockClear()
+  // ...
+})
+```
+
+### Component that calls `@/api/client`
+
+Same pattern as sonner — `vi.mock("@/api/client", …)` at file top, with `vi.fn()` for each API function the component calls. Returns are typically `Promise.resolve(...)` for happy path, `Promise.reject(new Error(...))` for error paths.
+
+```tsx
+vi.mock("@/api/client", () => ({
+  runScenarioNode: vi.fn().mockResolvedValue({ status: "success", duration_ms: 42, output_count: 100 }),
+  createRuleFromNode: vi.fn().mockResolvedValue({ id: "rule-1" }),
+}))
+```
+
+## Anti-patterns
+
+- ❌ **Don't wrap zustand stores in a Provider.** They're not Context-based ; a wrapper does nothing.
+- ❌ **Don't call `vi.mock` from inside a helper function.** Vitest hoists `vi.mock` calls to the top of the file at parse time. A helper that *calls* `vi.mock` won't have the same hoisting effect.
+- ❌ **Don't add a `<QueryClientProvider>`.** This codebase doesn't use react-query directly. The `useCapabilities` hook is hand-rolled with a module-level cache.
+- ❌ **Don't assume tests are isolated by default.** zustand stores leak. Use `setupStoreReset` if you mutate.
+
+## Adding a new helper
+
+If you find yourself copying the same setup 3+ times, extract it. Add the file under `src/__tests__/helpers/`, document it here, and ship a 1-2 case validation test demonstrating the helper works.

--- a/src/__tests__/helpers/__tests__/renderWithProviders.test.tsx
+++ b/src/__tests__/helpers/__tests__/renderWithProviders.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Validation tests for the renderWithProviders helper.
+ *
+ * Two angles :
+ * - The default mode (no routerEntries) renders the tree as a plain
+ *   `render()` would.
+ * - The router mode wires a MemoryRouter that satisfies useLocation /
+ *   useNavigate. Without this wrapper those hooks throw at render
+ *   time.
+ */
+
+import { describe, expect, it } from "vitest"
+import { screen } from "@testing-library/react"
+import { useLocation, useNavigate, Link } from "react-router-dom"
+
+import { renderWithProviders } from "../renderWithProviders"
+
+function PlainGreeting({ name }: { name: string }) {
+  return <p>Hello, {name}!</p>
+}
+
+function PathDisplay() {
+  const location = useLocation()
+  return <span data-testid="path">{location.pathname}</span>
+}
+
+function NavLink() {
+  const navigate = useNavigate()
+  return (
+    <button type="button" onClick={() => navigate("/dashboard")}>
+      Go
+    </button>
+  )
+}
+
+describe("renderWithProviders — plain mode", () => {
+  it("renders without a router when routerEntries is omitted", () => {
+    renderWithProviders(<PlainGreeting name="Test" />)
+    expect(screen.getByText("Hello, Test!")).toBeInTheDocument()
+  })
+
+  it("renders without a router when routerEntries is an empty array", () => {
+    renderWithProviders(<PlainGreeting name="Empty" />, { routerEntries: [] })
+    expect(screen.getByText("Hello, Empty!")).toBeInTheDocument()
+  })
+})
+
+describe("renderWithProviders — router mode", () => {
+  it("wires MemoryRouter when routerEntries is non-empty", () => {
+    renderWithProviders(<PathDisplay />, { routerEntries: ["/projects/abc"] })
+    expect(screen.getByTestId("path")).toHaveTextContent("/projects/abc")
+  })
+
+  it("respects routerInitialIndex when entries has multiple items", () => {
+    renderWithProviders(<PathDisplay />, {
+      routerEntries: ["/a", "/b", "/c"],
+      routerInitialIndex: 2,
+    })
+    expect(screen.getByTestId("path")).toHaveTextContent("/c")
+  })
+
+  it("provides useNavigate without crashing", () => {
+    // Just checking the render doesn't throw — the hook needs the
+    // router context to even initialise.
+    renderWithProviders(<NavLink />, { routerEntries: ["/"] })
+    expect(screen.getByRole("button", { name: "Go" })).toBeInTheDocument()
+  })
+
+  it("supports <Link>-rendering components", () => {
+    renderWithProviders(
+      <Link to="/dest">Go there</Link>,
+      { routerEntries: ["/"] },
+    )
+    const link = screen.getByRole("link", { name: "Go there" })
+    expect(link).toHaveAttribute("href", "/dest")
+  })
+})
+
+describe("renderWithProviders — RenderOptions passthrough", () => {
+  it("forwards container to the underlying render() call", () => {
+    const container = document.createElement("div")
+    container.id = "custom-root"
+    document.body.appendChild(container)
+
+    renderWithProviders(<PlainGreeting name="Container" />, {
+      container,
+    })
+
+    expect(container.querySelector("p")).toHaveTextContent("Hello, Container!")
+    document.body.removeChild(container)
+  })
+})

--- a/src/__tests__/helpers/__tests__/zustand.test.ts
+++ b/src/__tests__/helpers/__tests__/zustand.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Validation tests for setupStoreReset — uses the real localeStore
+ * since it has a stable initial state and no side-effects on import.
+ *
+ * Demonstrates the contract :
+ *   beforeAll  → snapshot the store's initial state
+ *   afterEach  → restore that snapshot (via setState replace = true)
+ *
+ * If the test order is correct, every `it` starts with the original
+ * locale regardless of what previous tests did.
+ */
+
+import { describe, expect, it } from "vitest"
+import { useLocaleStore } from "@/stores/localeStore"
+import { setupStoreReset } from "../zustand"
+
+describe("setupStoreReset — single store", () => {
+  // Capture the value seen on this test module's first render so we
+  // can compare each `it` start state against it.
+  const initialLocale = useLocaleStore.getState().locale
+
+  setupStoreReset(useLocaleStore)
+
+  it("first test sees the initial locale", () => {
+    expect(useLocaleStore.getState().locale).toBe(initialLocale)
+  })
+
+  it("a mutation in one test...", () => {
+    useLocaleStore.setState({ locale: "fr" })
+    expect(useLocaleStore.getState().locale).toBe("fr")
+  })
+
+  it("...does not leak into the next test", () => {
+    expect(useLocaleStore.getState().locale).toBe(initialLocale)
+  })
+
+  it("setState with new keys is wiped (replace mode = true)", () => {
+    // Add an extra key the store doesn't normally carry
+    useLocaleStore.setState({
+      locale: "fr",
+      // @ts-expect-error — intentionally adding an off-schema key
+      extraKey: "should-be-wiped",
+    })
+    expect(useLocaleStore.getState().locale).toBe("fr")
+    // @ts-expect-error — checking the key existed before reset
+    expect(useLocaleStore.getState().extraKey).toBe("should-be-wiped")
+  })
+
+  it("after the previous test, both the locale and the extra key are gone", () => {
+    expect(useLocaleStore.getState().locale).toBe(initialLocale)
+    // @ts-expect-error — checking the key was removed
+    expect(useLocaleStore.getState().extraKey).toBeUndefined()
+  })
+})

--- a/src/__tests__/helpers/__tests__/zustand.test.ts
+++ b/src/__tests__/helpers/__tests__/zustand.test.ts
@@ -51,4 +51,18 @@ describe("setupStoreReset — single store", () => {
     // @ts-expect-error — checking the key was removed
     expect(useLocaleStore.getState().extraKey).toBeUndefined()
   })
+
+  it("preserves action functions across reset (regression — JSON deep-clone would have dropped them)", () => {
+    // The localeStore declares setLocale + toggleLocale on the state
+    // object via `create((set, get) => ({ ..., setLocale: (l) => ... }))`.
+    // After our shallow-snapshot reset, both actions should still be
+    // callable. Failing this assertion means somebody re-introduced
+    // JSON deep-clone in setupStoreReset and wiped the actions.
+    const { setLocale, toggleLocale } = useLocaleStore.getState()
+    expect(typeof setLocale).toBe("function")
+    expect(typeof toggleLocale).toBe("function")
+    // Round-trip: call the action, observe state mutation.
+    setLocale("fr")
+    expect(useLocaleStore.getState().locale).toBe("fr")
+  })
 })

--- a/src/__tests__/helpers/renderWithProviders.tsx
+++ b/src/__tests__/helpers/renderWithProviders.tsx
@@ -1,0 +1,78 @@
+/**
+ * renderWithProviders — testing-library wrapper that adds the providers
+ * orchestrator components (NodePropertyPanel, TriggerBuilderInline /
+ * Modal, etc.) actually need at render time.
+ *
+ * Usage :
+ *
+ *   import { renderWithProviders } from "@/__tests__/helpers/renderWithProviders"
+ *
+ *   it("renders the run-node button", () => {
+ *     renderWithProviders(<NodePropertyPanel nodeId="x" nodeType="capability" />)
+ *     expect(screen.getByRole("button", { name: /run/i })).toBeInTheDocument()
+ *   })
+ *
+ * What it provides
+ * ----------------
+ * - **MemoryRouter** when `routerEntries` is passed. Components that use
+ *   `useNavigate` / `<Link>` need a router context ; without it Click
+ *   events on links throw `Cannot read properties of undefined (reading
+ *   'pathname')`. Pass an `initialEntries` array for the URL stack.
+ * - **Plain render** when no providers are needed. Identical to a bare
+ *   `render(ui)` call but keeps the call-site uniform.
+ *
+ * What it does NOT provide
+ * ------------------------
+ * - **Zustand stores** — those are module-level singletons. Use the
+ *   `setupStoreReset` helper (see `helpers/zustand.ts`) to snapshot &
+ *   restore initial state in `beforeEach`. Mocking stores wholesale is
+ *   discouraged — the components rely on subtle slice update semantics.
+ * - **sonner toast** — `vi.mock` calls are hoisted, so the mock has to
+ *   live at the top of each test file (not behind a helper). See
+ *   `helpers/README.md` for the canonical snippet.
+ * - **API client** — same reason as sonner, mock at file top.
+ * - **react-query / QueryClient** — not actually used in the codebase
+ *   (`useCapabilities` is hand-rolled with a module-level cache and
+ *   `_resetCapabilitiesCacheForTests()`). No QueryClientProvider needed.
+ */
+
+import { render, type RenderOptions, type RenderResult } from "@testing-library/react"
+import type { ReactElement, ReactNode } from "react"
+import { MemoryRouter } from "react-router-dom"
+
+export interface RenderWithProvidersOptions extends RenderOptions {
+  /**
+   * Wrap the tree in a MemoryRouter with these entries. Pass an empty
+   * array or omit to render without a router.
+   */
+  routerEntries?: string[]
+  /**
+   * Initial index into routerEntries (default 0). Forwarded to
+   * MemoryRouter.
+   */
+  routerInitialIndex?: number
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    routerEntries,
+    routerInitialIndex,
+    ...renderOptions
+  }: RenderWithProvidersOptions = {},
+): RenderResult {
+  function Wrapper({ children }: { children: ReactNode }) {
+    if (routerEntries && routerEntries.length > 0) {
+      return (
+        <MemoryRouter
+          initialEntries={routerEntries}
+          initialIndex={routerInitialIndex ?? 0}
+        >
+          {children}
+        </MemoryRouter>
+      )
+    }
+    return <>{children}</>
+  }
+  return render(ui, { wrapper: Wrapper, ...renderOptions })
+}

--- a/src/__tests__/helpers/zustand.ts
+++ b/src/__tests__/helpers/zustand.ts
@@ -26,10 +26,26 @@
  *
  *   setupStoreReset(useEditorStore, useDatasetStore, useProjectStore)
  *
- * The helper takes a snapshot of `getState()` at first call and uses
- * `setState(snapshot, true)` (replace = true) to restore in `afterEach`.
- * The snapshot is captured once per test module, before the first test
- * runs — assuming the store hasn't been mutated at module-load time.
+ * Snapshot strategy
+ * -----------------
+ * The helper captures `getState()` once before the first test (in
+ * `beforeAll`) and restores it via `setState(snapshot, true)` in
+ * `afterEach`. **No deep-clone** — the snapshot keeps function
+ * references intact so action methods (e.g. `setLocale`,
+ * `setNodeExecState`, `fetchRules`) survive the restore.
+ *
+ * This codebase declares store actions on the state object via the
+ * canonical `create((set, get) => ({ field, action: () => ... }))`
+ * pattern, so the actions LIVE on the state. A JSON deep-clone reset
+ * would drop those functions and the next test that triggers a
+ * handler calling them crashes with `TypeError: x is not a function`.
+ *
+ * Tradeoff: if a test mutates a nested object in place
+ * (`state.items.push(...)`), the mutation leaks into the snapshot's
+ * nested reference. Idiomatic zustand actions create new objects
+ * (immutable updates), so this is rarely a problem. If you hit it,
+ * do `useStore.setState({ items: [...newItems] })` instead of mutating
+ * an array in place.
  */
 
 import { afterEach, beforeAll } from "vitest"
@@ -49,13 +65,10 @@ export function setupStoreReset<TStores extends ZustandStore<unknown>[]>(
 
   beforeAll(() => {
     for (const store of stores) {
-      // Deep-clone via JSON to avoid sharing nested arrays/objects with
-      // the running state (a `setState({ items: [...] })` would mutate
-      // the snapshot otherwise). Functions are dropped — zustand actions
-      // live on the store closure, not on the state object, so this is
-      // safe for the default store shape. If a store puts callbacks in
-      // state (rare), use the store's own `_reset()` helper instead.
-      snapshots.set(store, JSON.parse(JSON.stringify(store.getState())))
+      // Capture the state object reference directly. JSON deep-clone
+      // would drop the action functions (this codebase keeps actions
+      // on the state object) — see the doc comment at the top.
+      snapshots.set(store, store.getState())
     }
   })
 
@@ -65,9 +78,13 @@ export function setupStoreReset<TStores extends ZustandStore<unknown>[]>(
       if (snapshot !== undefined) {
         // Replace mode (second arg `true`) wipes any keys added during
         // the test — without it, an extra key set via setState would
-        // survive the restore. We re-clone so subsequent tests can't
-        // mutate the snapshot.
-        store.setState(JSON.parse(JSON.stringify(snapshot)) as never, true)
+        // survive the restore. We rebuild a fresh top-level object so
+        // a test that does `state.foo = ...` (rare) doesn't tamper
+        // with our cached snapshot's identity.
+        store.setState(
+          { ...(snapshot as Record<string, unknown>) } as never,
+          true,
+        )
       }
     }
   })

--- a/src/__tests__/helpers/zustand.ts
+++ b/src/__tests__/helpers/zustand.ts
@@ -1,0 +1,74 @@
+/**
+ * zustand test helpers — snapshot/restore the initial store state so
+ * one test's mutations don't leak into the next.
+ *
+ * Why it's needed: zustand `create(...)` produces a module-level
+ * singleton. State mutations from `setState()` or store actions
+ * persist across tests in the same module load. Tests that touch the
+ * same store get order-dependent and flake silently.
+ *
+ * Usage :
+ *
+ *   import { useEditorStore } from "@/stores/editorStore"
+ *   import { setupStoreReset } from "@/__tests__/helpers/zustand"
+ *
+ *   describe("MyComponent", () => {
+ *     setupStoreReset(useEditorStore)
+ *
+ *     it("renders with default state", () => { ... })
+ *     it("reacts to state mutation", () => {
+ *       useEditorStore.setState({ activeScenarioId: "x" })
+ *       // ... assertions ...
+ *     })
+ *   })
+ *
+ * For multiple stores in one suite :
+ *
+ *   setupStoreReset(useEditorStore, useDatasetStore, useProjectStore)
+ *
+ * The helper takes a snapshot of `getState()` at first call and uses
+ * `setState(snapshot, true)` (replace = true) to restore in `afterEach`.
+ * The snapshot is captured once per test module, before the first test
+ * runs — assuming the store hasn't been mutated at module-load time.
+ */
+
+import { afterEach, beforeAll } from "vitest"
+
+interface ZustandStore<T> {
+  getState: () => T
+  setState: (
+    partial: T | Partial<T> | ((state: T) => T | Partial<T>),
+    replace?: true,
+  ) => void
+}
+
+export function setupStoreReset<TStores extends ZustandStore<unknown>[]>(
+  ...stores: TStores
+): void {
+  const snapshots = new Map<ZustandStore<unknown>, unknown>()
+
+  beforeAll(() => {
+    for (const store of stores) {
+      // Deep-clone via JSON to avoid sharing nested arrays/objects with
+      // the running state (a `setState({ items: [...] })` would mutate
+      // the snapshot otherwise). Functions are dropped — zustand actions
+      // live on the store closure, not on the state object, so this is
+      // safe for the default store shape. If a store puts callbacks in
+      // state (rare), use the store's own `_reset()` helper instead.
+      snapshots.set(store, JSON.parse(JSON.stringify(store.getState())))
+    }
+  })
+
+  afterEach(() => {
+    for (const store of stores) {
+      const snapshot = snapshots.get(store)
+      if (snapshot !== undefined) {
+        // Replace mode (second arg `true`) wipes any keys added during
+        // the test — without it, an extra key set via setState would
+        // survive the restore. We re-clone so subsequent tests can't
+        // mutate the snapshot.
+        store.setState(JSON.parse(JSON.stringify(snapshot)) as never, true)
+      }
+    }
+  })
+}


### PR DESCRIPTION
**Part A** of the user's \"A + B\" go-ahead — test infrastructure to unblock the orchestrator tests (NodePropertyPanel, TriggerBuilderInline, TriggerBuilderModal) listed in audit P1 #8 / issue #3.

## What's needed and what's not

The previous 4 trigger PRs (#12, #13, #14, #15) tested **prop-driven leaves** — no zustand, no react-router, no API. The orchestrators above all consume zustand stores + \`sonner\` toast + \`@/api/client\` ; without shared helpers each new test file re-implements the same boilerplate.

This PR ships the **3 helpers that compose** :

| Need | Helper / pattern |
|---|---|
| Component uses \`useNavigate\` / \`<Link>\` | \`renderWithProviders(ui, { routerEntries: [...] })\` |
| Component uses zustand store(s) | \`setupStoreReset(...stores)\` in \`describe\` |
| Component imports \`toast\` from sonner | \`vi.mock(\"sonner\", …)\` at file top — documented in README |
| Component calls \`@/api/client\` | \`vi.mock(\"@/api/client\", …)\` at file top — documented |
| Component uses \`useCapabilities\` | Existing \`_resetCapabilitiesCacheForTests()\` from the hook itself |

**Deliberately NOT shipped** :
- A QueryClientProvider — the codebase doesn't use react-query directly (\`useCapabilities\` is hand-rolled with a module-level cache).
- A wrapper around \`vi.mock(\"sonner\")\` — Vitest hoists \`vi.mock\` calls to the top of the file at parse time, so a helper that *calls* \`vi.mock\` wouldn't have the same effect. README ships the canonical snippet to copy.

## Files

- \`src/__tests__/helpers/renderWithProviders.tsx\` — testing-library wrapper. Adds MemoryRouter when \`routerEntries\` is non-empty, passes through RenderOptions otherwise.
- \`src/__tests__/helpers/zustand.ts\` — \`setupStoreReset(...stores)\` snapshots \`getState()\` in \`beforeAll\` and restores via \`setState(snapshot, true)\` in \`afterEach\`. Replace mode wipes any keys added during the test.
- \`src/__tests__/helpers/README.md\` — patterns documentation : when to use which helper, canonical \`vi.mock\` snippets, anti-patterns (don't add QueryClientProvider, don't wrap \`vi.mock\` in helpers).
- \`src/__tests__/helpers/__tests__/renderWithProviders.test.tsx\` — 7 validation cases (plain mode, router mode, useNavigate / useLocation / Link, RenderOptions passthrough).
- \`src/__tests__/helpers/__tests__/zustand.test.ts\` — 5 validation cases on the real \`localeStore\` (initial state visible, mutation does not leak, replace mode wipes extra keys).

## Tradeoffs documented in code comments

- **JSON deep-clone for store snapshot** — drops functions, which is fine because the codebase's store shape keeps actions in the closure, not on the state object. For stores that put callbacks in state (none today), expose a \`_reset()\` from the store itself.
- **No auto-reset across all stores** — each test suite explicitly opts in via \`setupStoreReset(...)\`. Auto-reset would require importing every store at infra-load time, slowing every test by milliseconds.

## Test plan

- [x] \`pnpm test src/__tests__/helpers\` — 12 passed in 552 ms.
- [x] \`pnpm test\` (full) — 138 passed (126 baseline + 12 new).
- [x] \`pnpm exec tsc --noEmit\` — clean.
- [ ] CI green.

## What this unblocks

After this lands, the next PRs can write component tests for :
- **NodePropertyPanel** (860 LOC, multi-store deps) — the headline target of audit P1 #8.
- **TriggerBuilderInline / TriggerBuilderModal** (orchestrators).
- Any future test on a workspace page that uses react-router.

Out of scope for this PR : actually writing those tests. This is just the runway.

## Stacking

Branch off \`origin/main\`. Independent of #11/#12/#13/#14/#15. The 6-PR stack will turn portal-libre coverage from 126 → 222 tests once everything lands :

| PR | Tests |
|---|---|
| #11 i18n PoC | +5 |
| #12 constants triggers | +22 |
| #13 CronBuilder | +12 |
| #14 ActionEditor | +21 |
| #15 shared.tsx | +24 |
| **this PR (helpers)** | **+12** |
| **Total** | **+96** |

(Plus the future PredicateBuilder PR — Part B — which doesn't depend on this infra since PredicateBuilder is also prop-driven.)