### PR TITLE
test: orchestrators + NodePropertyPanel — recovers stack from auto-closed #18/#19/#20

### DIFF
--- a/src/components/nodes/__tests__/NodePropertyPanel.test.tsx
+++ b/src/components/nodes/__tests__/NodePropertyPanel.test.tsx
@@ -1,0 +1,447 @@
+/**
+ * Component tests for NodePropertyPanel — the headline target of audit
+ * P1 #8 / issue #3. 860 LOC, 4 zustand stores, 2 API calls, multiple
+ * node-type forks. Exercises the same scaffolding as
+ * TriggerBuilderInline.test.tsx (PR #18) plus a vi.mock("@/api/client")
+ * for the runScenarioNode + createRuleFromNode imports.
+ *
+ * What's covered (organised by surface)
+ * -------------------------------------
+ *   Header / id / exec status badge
+ *   Run node — schema-error gate, no-scenario gate, success path,
+ *              backend-failure path
+ *   Save as Rule — visible-on-capability gate, success path, error path
+ *   Dataset Source render fork
+ *   Trigger node fork (type-conditional fields)
+ *   Capability node fork (capability dropdown, fallback list)
+ *   Label edits propagate via updateNodeData
+ *
+ * What's NOT covered (deliberate)
+ * --------------------------------
+ *   - Schema-driven SchemaForm rendering — covered by SchemaForm's own
+ *     test file (`__tests__/SchemaForm.test.tsx`).
+ *   - i18n FR variants of the toast messages — not value-add given the
+ *     PR #11 i18n PoC migration covers the locale toggle path.
+ *   - Code / branch / output / control node forks — render simple
+ *     read-only sections, low risk of regression.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+// vi.mock calls are hoisted by Vitest to the very top of the module —
+// they MUST come before the component import so the mocks replace the
+// real implementations before NodePropertyPanel is evaluated.
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}))
+
+vi.mock("@/api/client", () => ({
+  runScenarioNode: vi.fn(),
+  createRuleFromNode: vi.fn(),
+}))
+
+import { toast } from "sonner"
+import { runScenarioNode, createRuleFromNode } from "@/api/client"
+import { NodePropertyPanel } from "../NodePropertyPanel"
+import { useEditorStore } from "@/stores/editorStore"
+import { useDatasetStore } from "@/stores/datasetStore"
+import { useProjectStore } from "@/stores/projectStore"
+import { useLocaleStore } from "@/stores/localeStore"
+import { setupStoreReset } from "@/__tests__/helpers/zustand"
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("NodePropertyPanel", () => {
+  setupStoreReset(useEditorStore, useDatasetStore, useProjectStore, useLocaleStore)
+
+  beforeEach(() => {
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(runScenarioNode).mockReset()
+    vi.mocked(createRuleFromNode).mockReset()
+  })
+
+  // -------------------------------------------------------------------------
+  // Header / id / label
+  // -------------------------------------------------------------------------
+
+  describe("header", () => {
+    it("renders the label from nodeData", () => {
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="capability"
+          nodeData={{ label: "My Buffer Step" }}
+        />,
+      )
+      expect(screen.getByRole("heading", { name: "My Buffer Step" })).toBeInTheDocument()
+    })
+
+    it("falls back to 'Node' when label is missing", () => {
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      expect(screen.getByRole("heading", { name: "Node" })).toBeInTheDocument()
+    })
+
+    it("renders the node id under the header", () => {
+      render(<NodePropertyPanel nodeId="my-special-id" nodeType="capability" />)
+      expect(screen.getByText("ID: my-special-id")).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Execution status badge
+  // -------------------------------------------------------------------------
+
+  describe("execution status", () => {
+    it("renders nothing when no execState exists for the node", () => {
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      expect(screen.queryByText(/^success$/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^failed$/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/^running$/i)).not.toBeInTheDocument()
+    })
+
+    it("shows the success status with duration when execState.status='success'", () => {
+      useEditorStore.setState({
+        nodeExecStates: {
+          "n-1": { status: "success", duration_ms: 142 },
+        },
+      })
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      expect(screen.getByText("success")).toBeInTheDocument()
+      expect(screen.getByText("142ms")).toBeInTheDocument()
+    })
+
+    it("shows the failed status with the error message", () => {
+      useEditorStore.setState({
+        nodeExecStates: {
+          "n-1": { status: "failed", error: "Capability not found" },
+        },
+      })
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      expect(screen.getByText("failed")).toBeInTheDocument()
+      expect(screen.getByText("Capability not found")).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Run node — gates + happy/sad paths
+  // -------------------------------------------------------------------------
+
+  describe("Run node button", () => {
+    it("is disabled when there is no active scenario", () => {
+      useEditorStore.setState({ activeScenarioId: null })
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      expect(screen.getByRole("button", { name: /run node/i })).toBeDisabled()
+    })
+
+    it("is enabled when active scenario is set and no schema errors", () => {
+      useEditorStore.setState({ activeScenarioId: "scn-1" })
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      expect(screen.getByRole("button", { name: /run node/i })).toBeEnabled()
+    })
+
+    it("toasts an error when clicked without active scenario (defensive — disabled UI is the primary gate)", async () => {
+      useEditorStore.setState({ activeScenarioId: null })
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      // The button is disabled in this state, but the handler also has
+      // a guard. Force-call the handler via the bookmark helper :
+      // simulate by setting active first, rendering, then clearing.
+      // Simpler : re-render with active set, then check guard
+      // independently. Here we just verify the disabled state stops
+      // submission entirely.
+      fireEvent.click(screen.getByRole("button", { name: /run node/i }))
+      // No API call should fire when the button was disabled.
+      expect(vi.mocked(runScenarioNode)).not.toHaveBeenCalled()
+    })
+
+    it("calls runScenarioNode on click and toasts success on resolved", async () => {
+      useEditorStore.setState({ activeScenarioId: "scn-1" })
+      vi.mocked(runScenarioNode).mockResolvedValue({
+        status: "success",
+        duration_ms: 250,
+        output_count: 42,
+      })
+
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      fireEvent.click(screen.getByRole("button", { name: /run node/i }))
+
+      await waitFor(() => {
+        expect(vi.mocked(runScenarioNode)).toHaveBeenCalledWith("scn-1", "n-1", {})
+      })
+      await waitFor(() => {
+        expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+          "Node ran successfully (42 features, 250ms)",
+        )
+      })
+    })
+
+    it("toasts the failed status with backend-reported error", async () => {
+      useEditorStore.setState({ activeScenarioId: "scn-1" })
+      vi.mocked(runScenarioNode).mockResolvedValue({
+        status: "failed",
+        error: "Capability raised RuntimeError",
+        duration_ms: 50,
+      })
+
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      fireEvent.click(screen.getByRole("button", { name: /run node/i }))
+
+      await waitFor(() => {
+        expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+          "Node failed: Capability raised RuntimeError",
+        )
+      })
+    })
+
+    it("toasts the network failure when runScenarioNode rejects", async () => {
+      useEditorStore.setState({ activeScenarioId: "scn-1" })
+      vi.mocked(runScenarioNode).mockRejectedValue(new Error("ECONNRESET"))
+
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      fireEvent.click(screen.getByRole("button", { name: /run node/i }))
+
+      await waitFor(() => {
+        expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+          "Run failed: ECONNRESET",
+        )
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Save as Rule — visible only on capability nodes
+  // -------------------------------------------------------------------------
+
+  describe("Save as Rule button", () => {
+    it("is rendered on capability nodes", () => {
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      expect(screen.getByRole("button", { name: /save as rule/i })).toBeInTheDocument()
+    })
+
+    it("is NOT rendered on datasetSource nodes", () => {
+      useDatasetStore.setState({ datasets: [] })
+      render(<NodePropertyPanel nodeId="n-1" nodeType="datasetSource" />)
+      expect(screen.queryByRole("button", { name: /save as rule/i })).not.toBeInTheDocument()
+    })
+
+    it("is NOT rendered on output nodes", () => {
+      render(<NodePropertyPanel nodeId="n-1" nodeType="output" />)
+      expect(screen.queryByRole("button", { name: /save as rule/i })).not.toBeInTheDocument()
+    })
+
+    it("calls createRuleFromNode and refreshes rules + toasts success", async () => {
+      const fetchRules = vi.fn().mockResolvedValue(undefined)
+      useProjectStore.setState({ fetchRules })
+      vi.mocked(createRuleFromNode).mockResolvedValue({ id: "rule-42" })
+
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="capability"
+          nodeData={{
+            label: "Buffer 50m",
+            capability: "buffer",
+            config: { distance: 50, units: "meters" },
+          }}
+        />,
+      )
+      fireEvent.click(screen.getByRole("button", { name: /save as rule/i }))
+
+      await waitFor(() => {
+        expect(vi.mocked(createRuleFromNode)).toHaveBeenCalledWith({
+          capability: "buffer",
+          label: "Buffer 50m",
+          params: { distance: 50, units: "meters" },
+          description: 'Rule saved from node "Buffer 50m"',
+        })
+      })
+      expect(fetchRules).toHaveBeenCalledOnce()
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
+        'Rule "Buffer 50m" saved. It now appears in My Rules.',
+      )
+    })
+
+    it("toasts the failure when createRuleFromNode rejects", async () => {
+      useProjectStore.setState({ fetchRules: vi.fn() })
+      vi.mocked(createRuleFromNode).mockRejectedValue(new Error("Validation failed"))
+
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="capability"
+          nodeData={{
+            label: "Bad rule",
+            capability: "buffer",
+            config: {},
+          }}
+        />,
+      )
+      fireEvent.click(screen.getByRole("button", { name: /save as rule/i }))
+
+      await waitFor(() => {
+        expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+          "Save as Rule failed: Validation failed",
+        )
+      })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Dataset source fork
+  // -------------------------------------------------------------------------
+
+  describe("datasetSource node", () => {
+    it("renders the dataset dropdown populated from useDatasetStore", () => {
+      useDatasetStore.setState({
+        datasets: [
+          { id: "ds-1", name: "Parcels", layers: [{ name: "parcels", feature_count: 100 }] },
+          { id: "ds-2", name: "Buildings", layers: [] },
+        ] as unknown as ReturnType<typeof useDatasetStore.getState>["datasets"],
+      })
+      render(<NodePropertyPanel nodeId="n-1" nodeType="datasetSource" />)
+      expect(screen.getByRole("option", { name: "Parcels" })).toBeInTheDocument()
+      expect(screen.getByRole("option", { name: "Buildings" })).toBeInTheDocument()
+    })
+
+    it("renders the layer dropdown only after a dataset is selected", () => {
+      useDatasetStore.setState({
+        datasets: [
+          {
+            id: "ds-1",
+            name: "Parcels",
+            layers: [
+              { name: "parcels", feature_count: 100 },
+              { name: "neighborhoods", feature_count: 5 },
+            ],
+          },
+        ] as unknown as ReturnType<typeof useDatasetStore.getState>["datasets"],
+      })
+      // Initially no datasetId in nodeData → no Layer field.
+      const { rerender } = render(
+        <NodePropertyPanel nodeId="n-1" nodeType="datasetSource" />,
+      )
+      expect(screen.queryByText("Layer")).not.toBeInTheDocument()
+
+      // After selecting a dataset, the Layer field shows up with the
+      // `feature_count` summary.
+      rerender(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="datasetSource"
+          nodeData={{ datasetId: "ds-1" }}
+        />,
+      )
+      expect(screen.getByText("Layer")).toBeInTheDocument()
+      expect(screen.getByRole("option", { name: "parcels (100)" })).toBeInTheDocument()
+      expect(screen.getByRole("option", { name: "neighborhoods (5)" })).toBeInTheDocument()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Trigger node fork — conditional fields by triggerType
+  // -------------------------------------------------------------------------
+
+  describe("trigger node", () => {
+    it("On DML : Event select renders, Cron + Threshold inputs hidden", () => {
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="trigger"
+          nodeData={{ triggerType: "On DML", eventType: "INSERT" }}
+        />,
+      )
+      // Event select has 'INSERT' as its current value
+      const ev = screen
+        .getAllByRole("combobox")
+        .find((el) => (el as HTMLSelectElement).value === "INSERT")
+      expect(ev).toBeTruthy()
+      expect(screen.queryByPlaceholderText("*/5 * * * *")).not.toBeInTheDocument()
+      expect(screen.queryByPlaceholderText("count > 100")).not.toBeInTheDocument()
+    })
+
+    it("On Schedule : Cron input renders, Event select hidden", () => {
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="trigger"
+          nodeData={{ triggerType: "On Schedule", cron: "*/15 * * * *" }}
+        />,
+      )
+      expect(screen.getByPlaceholderText("*/5 * * * *")).toHaveValue("*/15 * * * *")
+      expect(screen.queryByText("Event")).not.toBeInTheDocument()
+    })
+
+    it("On Threshold : Threshold input renders", () => {
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="trigger"
+          nodeData={{ triggerType: "On Threshold", threshold: "count > 500" }}
+        />,
+      )
+      expect(screen.getByPlaceholderText("count > 100")).toHaveValue("count > 500")
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Capability node fork — capability dropdown
+  // -------------------------------------------------------------------------
+
+  describe("capability node", () => {
+    it("renders the capability fallback list when caps registry is empty", () => {
+      // Default useCapabilities cache is null/empty in this test session.
+      render(<NodePropertyPanel nodeId="n-1" nodeType="capability" />)
+      // Fallback set contains 'buffer', 'spatial_join' etc.
+      expect(screen.getByRole("option", { name: "buffer" })).toBeInTheDocument()
+      expect(screen.getByRole("option", { name: "spatial_join" })).toBeInTheDocument()
+    })
+
+    it("uses the current capability value from nodeData", () => {
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="capability"
+          nodeData={{ capability: "buffer" }}
+        />,
+      )
+      // The capability select's current value is 'buffer'.
+      const sel = screen
+        .getAllByRole("combobox")
+        .find((el) => (el as HTMLSelectElement).value === "buffer")
+      expect(sel).toBeTruthy()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Label edits
+  // -------------------------------------------------------------------------
+
+  describe("label edits", () => {
+    it("calls updateNodeData('label', value) when the Label input changes", () => {
+      const updateNodeData = vi.fn()
+      useEditorStore.setState({ updateNodeData })
+
+      render(
+        <NodePropertyPanel
+          nodeId="n-1"
+          nodeType="capability"
+          nodeData={{ label: "Original" }}
+        />,
+      )
+      // The Label input has the trigger node's `value="Original"` —
+      // find it by the displayed value.
+      const input = screen.getByDisplayValue("Original")
+      fireEvent.change(input, { target: { value: "Edited Label" } })
+      expect(updateNodeData).toHaveBeenCalledWith("n-1", "label", "Edited Label")
+    })
+  })
+})

--- a/src/components/triggers/__tests__/TriggerBuilderInline.test.tsx
+++ b/src/components/triggers/__tests__/TriggerBuilderInline.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * Component tests for TriggerBuilderInline — first orchestrator test
+ * exercising the helpers from PR #16 (renderWithProviders +
+ * setupStoreReset) and the README's vi.mock("sonner") pattern.
+ *
+ * What's covered:
+ * - Missing trigger : the "Trigger not found" placeholder.
+ * - Header : trigger name, enabled badge.
+ * - Identity / Type / Conditions / Spatial Ops / Actions / Review
+ *   collapsible sections render with the right counts and content.
+ * - Field edits update local state but mark the form dirty (Save
+ *   button enabled, "Unsaved changes" banner).
+ * - Triggers with conditional content : "On Schedule" shows Cron,
+ *   "On Threshold" shows Expression, "On DML" shows Event.
+ * - Save handler : empty name → toast.error + no updateTrigger call.
+ * - Save handler : happy path → updateTrigger called with merged
+ *   payload + toast.success.
+ * - Save handler : updateTrigger rejects → toast.error with the
+ *   formatted message + saving state cleared.
+ * - "Full editor" button calls openTriggerBuilder(triggerId).
+ *
+ * Validation of the test infra : if the helpers from PR #16 work as
+ * advertised, this file should pass without any new mocking
+ * boilerplate beyond the documented patterns.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+
+// vi.mock("sonner") MUST be at file top (Vitest hoists it before the
+// component import so the toast spies replace the real implementation
+// before the component module is evaluated).
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}))
+
+import { toast } from "sonner"
+import { TriggerBuilderInline } from "../TriggerBuilderInline"
+import { useProjectStore } from "@/stores/projectStore"
+import { useEditorStore } from "@/stores/editorStore"
+import { setupStoreReset } from "@/__tests__/helpers/zustand"
+import type { Trigger } from "@/types/project"
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+function makeTrigger(overrides: Partial<Trigger> = {}): Trigger {
+  return {
+    id: "trig-1",
+    name: "My Trigger",
+    event: "INSERT",
+    trigger_type: "On DML",
+    rule_id: null,
+    conditions: { table: "parcels" },
+    enabled: true,
+    severity: "info",
+    ...overrides,
+  }
+}
+
+function seedTrigger(t: Trigger) {
+  useProjectStore.setState({ triggers: [t] })
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("TriggerBuilderInline", () => {
+  // Reset both stores between tests so seeded triggers / open state
+  // don't leak. This is what audit P1 #8 was waiting on — the helper
+  // infra from PR #16 makes orchestrator tests possible without
+  // re-implementing snapshot/restore in every file.
+  setupStoreReset(useProjectStore, useEditorStore)
+
+  beforeEach(() => {
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.error).mockClear()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Missing trigger fallback
+  // ---------------------------------------------------------------------------
+
+  it("renders a 'Trigger not found' placeholder when the id is unknown", () => {
+    render(<TriggerBuilderInline triggerId="ghost-id" />)
+    expect(screen.getByText(/trigger not found/i)).toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Header
+  // ---------------------------------------------------------------------------
+
+  it("renders the trigger name in the header", () => {
+    seedTrigger(makeTrigger({ name: "Audit New Parcels" }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.getByRole("heading", { name: "Audit New Parcels" })).toBeInTheDocument()
+  })
+
+  it("shows the 'on' enabled badge for enabled triggers", () => {
+    seedTrigger(makeTrigger({ enabled: true }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.getByText("on")).toBeInTheDocument()
+  })
+
+  it("shows the 'off' enabled badge for disabled triggers", () => {
+    seedTrigger(makeTrigger({ enabled: false }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.getByText("off")).toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Identity section
+  // ---------------------------------------------------------------------------
+
+  it("populates the Name input from the trigger", () => {
+    seedTrigger(makeTrigger({ name: "InitialName" }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.getByPlaceholderText("Trigger name")).toHaveValue("InitialName")
+  })
+
+  it("populates the Severity select from the trigger", () => {
+    seedTrigger(makeTrigger({ severity: "warning" }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    const sev = screen
+      .getAllByRole("combobox")
+      .find((el) => (el as HTMLSelectElement).value === "warning")
+    expect(sev).toBeTruthy()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Type section — conditional fields
+  // ---------------------------------------------------------------------------
+
+  it("On DML : shows the Event select", () => {
+    seedTrigger(makeTrigger({ trigger_type: "On DML", event: "UPDATE" }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    const ev = screen
+      .getAllByRole("combobox")
+      .find((el) => (el as HTMLSelectElement).value === "UPDATE")
+    expect(ev).toBeTruthy()
+  })
+
+  it("On Schedule : shows the Cron input instead of Event", () => {
+    seedTrigger(
+      makeTrigger({
+        trigger_type: "On Schedule",
+        conditions: { table: "x", cron: "*/5 * * * *" },
+      }),
+    )
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.getByPlaceholderText("*/5 * * * *")).toHaveValue("*/5 * * * *")
+  })
+
+  it("On Threshold : shows the Expression input", () => {
+    seedTrigger(
+      makeTrigger({
+        trigger_type: "On Threshold",
+        conditions: { table: "x", threshold: "count > 100" },
+      }),
+    )
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.getByPlaceholderText("count > 100")).toHaveValue("count > 100")
+  })
+
+  // ---------------------------------------------------------------------------
+  // Conditions / Spatial Ops / Actions section badges
+  // ---------------------------------------------------------------------------
+
+  it("Conditions badge counts the predicates", () => {
+    seedTrigger(
+      makeTrigger({
+        conditions: {
+          table: "x",
+          predicates: {
+            predicates: [
+              { type: "attr", field: "a", op: "eq", value: 1 },
+              { type: "attr", field: "b", op: "eq", value: 2 },
+              { type: "attr", field: "c", op: "eq", value: 3 },
+            ],
+          },
+        },
+      }),
+    )
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    // Conditions section header has the count badge.
+    const badge = screen.getByText("3")
+    expect(badge).toBeInTheDocument()
+  })
+
+  it("Spatial Ops badge counts operations", () => {
+    seedTrigger(
+      makeTrigger({
+        conditions: {
+          table: "x",
+          operations: [
+            { operation: "ST_Within", phase: "before" },
+            { operation: "ST_Buffer", phase: "after" },
+          ],
+        },
+      }),
+    )
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.getByText("2")).toBeInTheDocument()
+  })
+
+  it("Actions section shows 'No actions configured.' when empty", () => {
+    seedTrigger(makeTrigger())
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    // The Actions panel is collapsed by default, expand it.
+    fireEvent.click(screen.getByRole("button", { name: /actions/i }))
+    expect(screen.getByText("No actions configured.")).toBeInTheDocument()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Dirty state
+  // ---------------------------------------------------------------------------
+
+  it("does not show 'Unsaved changes' when nothing was edited", () => {
+    seedTrigger(makeTrigger())
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument()
+  })
+
+  it("shows 'Unsaved changes' once the Name is edited", () => {
+    seedTrigger(makeTrigger({ name: "Original" }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    fireEvent.change(screen.getByPlaceholderText("Trigger name"), {
+      target: { value: "Edited" },
+    })
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument()
+  })
+
+  it("disables the Save button when the form is pristine", () => {
+    seedTrigger(makeTrigger())
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    const save = screen.getByRole("button", { name: /save/i })
+    expect(save).toBeDisabled()
+  })
+
+  it("enables the Save button when the form is dirty", () => {
+    seedTrigger(makeTrigger({ name: "Original" }))
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    fireEvent.change(screen.getByPlaceholderText("Trigger name"), {
+      target: { value: "Edited" },
+    })
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Save handler
+  // ---------------------------------------------------------------------------
+
+  it("Save with an empty name toasts an error and does NOT call updateTrigger", async () => {
+    const updateTrigger = vi.fn<typeof useProjectStore.getState.prototype.updateTrigger>()
+    seedTrigger(makeTrigger({ name: "Original" }))
+    useProjectStore.setState({ updateTrigger })
+
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    fireEvent.change(screen.getByPlaceholderText("Trigger name"), {
+      target: { value: "   " }, // whitespace-only ⇒ trim to empty
+    })
+    fireEvent.click(screen.getByRole("button", { name: /save/i }))
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith("Name is required.")
+    })
+    expect(updateTrigger).not.toHaveBeenCalled()
+  })
+
+  it("Save happy path : calls updateTrigger with the trimmed name and toasts success", async () => {
+    const updateTrigger = vi
+      .fn()
+      .mockResolvedValue(undefined)
+    seedTrigger(makeTrigger({ name: "Original" }))
+    useProjectStore.setState({ updateTrigger })
+
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    fireEvent.change(screen.getByPlaceholderText("Trigger name"), {
+      target: { value: "New Name" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /save/i }))
+
+    await waitFor(() => {
+      expect(updateTrigger).toHaveBeenCalledOnce()
+    })
+    const [id, payload] = updateTrigger.mock.calls[0]!
+    expect(id).toBe("trig-1")
+    expect(payload.name).toBe("New Name")
+    expect(payload.trigger_type).toBe("On DML")
+    expect(vi.mocked(toast.success)).toHaveBeenCalledWith('Trigger "New Name" saved')
+  })
+
+  it("Save with surrounding whitespace : payload is trimmed but the success toast quotes the raw input (existing UX quirk)", async () => {
+    // Documents — does not endorse — the current behaviour : the toast
+    // string interpolates `name` (un-trimmed local state) while the
+    // updateTrigger payload uses `name.trim()`. Worth a tiny follow-up
+    // fix to align the two ; until then, this test pins the contract.
+    const updateTrigger = vi.fn().mockResolvedValue(undefined)
+    seedTrigger(makeTrigger({ name: "Original" }))
+    useProjectStore.setState({ updateTrigger })
+
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    fireEvent.change(screen.getByPlaceholderText("Trigger name"), {
+      target: { value: "  Padded  " },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /save/i }))
+
+    await waitFor(() => {
+      expect(updateTrigger).toHaveBeenCalledOnce()
+    })
+    expect(updateTrigger.mock.calls[0]![1].name).toBe("Padded") // payload trimmed
+    expect(vi.mocked(toast.success)).toHaveBeenCalledWith('Trigger "  Padded  " saved') // toast un-trimmed
+  })
+
+  it("Save with a rejected updateTrigger toasts the formatted error", async () => {
+    const updateTrigger = vi
+      .fn()
+      .mockRejectedValue(new Error("Backend offline"))
+    seedTrigger(makeTrigger({ name: "Original" }))
+    useProjectStore.setState({ updateTrigger })
+
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    fireEvent.change(screen.getByPlaceholderText("Trigger name"), {
+      target: { value: "Edited" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: /save/i }))
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+        "Save failed: Backend offline",
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Full editor button
+  // ---------------------------------------------------------------------------
+
+  it("'Full editor' button calls openTriggerBuilder with the trigger id", () => {
+    const openTriggerBuilder = vi.fn()
+    seedTrigger(makeTrigger())
+    useEditorStore.setState({ openTriggerBuilder })
+
+    render(<TriggerBuilderInline triggerId="trig-1" />)
+    fireEvent.click(screen.getByRole("button", { name: /full editor/i }))
+    expect(openTriggerBuilder).toHaveBeenCalledWith("trig-1")
+  })
+})

--- a/src/components/triggers/__tests__/TriggerBuilderModal.test.tsx
+++ b/src/components/triggers/__tests__/TriggerBuilderModal.test.tsx
@@ -1,0 +1,503 @@
+/**
+ * Component tests for TriggerBuilderModal — closes the last leaf in
+ * audit P1 #8 / issue #3 (and the orchestrator pair with
+ * TriggerBuilderInline #18).
+ *
+ * Strategy : mock the two orchestration hooks (`useTriggerForm`,
+ * `useTriggerStepper`) so we can drive the modal into specific states
+ * (open / closed, first / last step, dirty / clean, editing / new)
+ * without seeding the underlying stores. The 6 step subcomponents are
+ * stubbed too — their rendering is irrelevant for the modal-shell
+ * tests, and they pull in even more context (zustand + sonner +
+ * api/client).
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import type { TriggerType } from "@/types/editor"
+
+// vi.mock calls hoisted to module top — must come before component
+// import. We provide a factory so each test can swap the return
+// values via vi.mocked(...).mockReturnValue(...).
+vi.mock("@/components/triggers/hooks/useTriggerForm", () => ({
+  useTriggerForm: vi.fn(),
+}))
+vi.mock("@/components/triggers/hooks/useTriggerStepper", () => ({
+  useTriggerStepper: vi.fn(),
+}))
+
+// Stub the 6 step subcomponents — their internal rendering is out of
+// scope (covered by the leaf PRs : ActionEditor, PredicateBuilder, etc.).
+vi.mock("../steps/StepIdentity", () => ({
+  StepIdentity: () => <div data-testid="step-identity">Identity step</div>,
+}))
+vi.mock("../steps/StepTypeConfig", () => ({
+  StepTypeConfig: () => <div data-testid="step-config">Config step</div>,
+}))
+vi.mock("../steps/StepSpatialOps", () => ({
+  StepSpatialOps: () => <div data-testid="step-spatial">Spatial step</div>,
+}))
+vi.mock("../steps/StepConditions", () => ({
+  StepConditions: () => <div data-testid="step-conditions">Conditions step</div>,
+}))
+vi.mock("../steps/StepActions", () => ({
+  StepActions: () => <div data-testid="step-actions">Actions step</div>,
+}))
+vi.mock("../steps/StepReview", () => ({
+  StepReview: () => <div data-testid="step-review">Review step</div>,
+}))
+
+import { TriggerBuilderModal } from "../TriggerBuilderModal"
+import { useTriggerForm } from "@/components/triggers/hooks/useTriggerForm"
+import { useTriggerStepper } from "@/components/triggers/hooks/useTriggerStepper"
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+interface FormOverrides {
+  isEditing?: boolean
+  triggerBuilderOpen?: boolean
+  closeTriggerBuilder?: () => void
+  name?: string
+  severity?: "info" | "warning" | "error" | "critical"
+  setSeverity?: (s: string) => void
+  triggerType?: TriggerType
+  predicates?: { predicates: unknown[] }
+  actions?: unknown[]
+  operations?: unknown[]
+  saving?: boolean
+  canSave?: boolean
+  handleSave?: () => void | Promise<void>
+}
+
+function makeForm(overrides: FormOverrides = {}) {
+  return {
+    isEditing: false,
+    triggerBuilderOpen: true,
+    closeTriggerBuilder: vi.fn(),
+    name: "My Trigger",
+    severity: "info",
+    setSeverity: vi.fn(),
+    triggerType: "dml" as TriggerType,
+    predicates: { predicates: [] },
+    actions: [],
+    operations: [],
+    saving: false,
+    canSave: true,
+    handleSave: vi.fn(),
+    ...overrides,
+  }
+}
+
+interface StepperOverrides {
+  steps?: { id: string; label: string; visible: boolean }[]
+  activeStep?: number
+  currentStep?: { id: string; label: string }
+  isFirst?: boolean
+  isLast?: boolean
+  goNext?: () => void
+  goPrev?: () => void
+  goTo?: (idx: number) => void
+  reset?: () => void
+}
+
+function makeStepper(overrides: StepperOverrides = {}) {
+  const steps = overrides.steps ?? [
+    { id: "identity", label: "Identity", visible: true },
+    { id: "config", label: "Config", visible: true },
+    { id: "spatial", label: "Spatial", visible: true },
+    { id: "conditions", label: "Conditions", visible: true },
+    { id: "actions", label: "Actions", visible: true },
+    { id: "review", label: "Review", visible: true },
+  ]
+  const activeStep = overrides.activeStep ?? 0
+  const currentStep = overrides.currentStep ?? steps[activeStep]!
+  return {
+    steps,
+    activeStep,
+    currentStep,
+    isFirst: overrides.isFirst ?? activeStep === 0,
+    isLast: overrides.isLast ?? activeStep === steps.length - 1,
+    goNext: overrides.goNext ?? vi.fn(),
+    goPrev: overrides.goPrev ?? vi.fn(),
+    goTo: overrides.goTo ?? vi.fn(),
+    reset: overrides.reset ?? vi.fn(),
+  }
+}
+
+function setMocks(
+  formOverrides: FormOverrides = {},
+  stepperOverrides: StepperOverrides = {},
+) {
+  const form = makeForm(formOverrides)
+  const stepper = makeStepper(stepperOverrides)
+  vi.mocked(useTriggerForm).mockReturnValue(form as never)
+  vi.mocked(useTriggerStepper).mockReturnValue(stepper as never)
+  return { form, stepper }
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("TriggerBuilderModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // Visibility
+  // -------------------------------------------------------------------------
+
+  it("returns null when triggerBuilderOpen is false", () => {
+    setMocks({ triggerBuilderOpen: false })
+    const { container } = render(<TriggerBuilderModal />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders the dialog when triggerBuilderOpen is true", () => {
+    setMocks()
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Header — title + name + close
+  // -------------------------------------------------------------------------
+
+  it("shows 'New Trigger' title in create mode", () => {
+    setMocks({ isEditing: false })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("heading", { name: "New Trigger" })).toBeInTheDocument()
+  })
+
+  it("shows 'Edit Trigger' title in edit mode", () => {
+    setMocks({ isEditing: true })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("heading", { name: "Edit Trigger" })).toBeInTheDocument()
+  })
+
+  it("renders the trigger name as a subtitle when set", () => {
+    setMocks({ name: "Audit Parcels" })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByText("Audit Parcels")).toBeInTheDocument()
+  })
+
+  it("hides the name subtitle when name is empty", () => {
+    setMocks({ name: "" })
+    render(<TriggerBuilderModal />)
+    // No subtitle renders for an empty name
+    const dialog = screen.getByRole("dialog")
+    expect(dialog.querySelectorAll("p.truncate")).toHaveLength(0)
+  })
+
+  it("close button (X) calls closeTriggerBuilder", () => {
+    const closeTriggerBuilder = vi.fn()
+    setMocks({ closeTriggerBuilder })
+    render(<TriggerBuilderModal />)
+    fireEvent.click(screen.getByRole("button", { name: /close/i }))
+    expect(closeTriggerBuilder).toHaveBeenCalledOnce()
+  })
+
+  it("backdrop click calls closeTriggerBuilder", () => {
+    const closeTriggerBuilder = vi.fn()
+    setMocks({ closeTriggerBuilder })
+    const { container } = render(<TriggerBuilderModal />)
+    const backdrop = container.querySelector('[aria-hidden="true"]')
+    expect(backdrop).toBeTruthy()
+    fireEvent.click(backdrop!)
+    expect(closeTriggerBuilder).toHaveBeenCalledOnce()
+  })
+
+  // -------------------------------------------------------------------------
+  // Severity selector
+  // -------------------------------------------------------------------------
+
+  it("renders all 4 severity buttons", () => {
+    setMocks()
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("button", { name: /info/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /warning/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /error/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /critical/i })).toBeInTheDocument()
+  })
+
+  it("highlights the active severity with the bg color class", () => {
+    setMocks({ severity: "warning" })
+    render(<TriggerBuilderModal />)
+    const warningBtn = screen.getByRole("button", { name: /warning/i })
+    expect(warningBtn.className).toContain("bg-amber-500")
+  })
+
+  it("clicking a severity calls setSeverity", () => {
+    const setSeverity = vi.fn()
+    setMocks({ setSeverity })
+    render(<TriggerBuilderModal />)
+    fireEvent.click(screen.getByRole("button", { name: /critical/i }))
+    expect(setSeverity).toHaveBeenCalledWith("critical")
+  })
+
+  // -------------------------------------------------------------------------
+  // Stepper bar
+  // -------------------------------------------------------------------------
+
+  it("renders all visible step buttons in the stepper", () => {
+    setMocks()
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("button", { name: /identity/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /config/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /review/i })).toBeInTheDocument()
+  })
+
+  it("clicking a step button calls goTo with its index", () => {
+    const goTo = vi.fn()
+    setMocks({}, { goTo })
+    render(<TriggerBuilderModal />)
+    fireEvent.click(screen.getByRole("button", { name: /spatial/i }))
+    // Spatial is step index 2 in the default 6-step layout.
+    expect(goTo).toHaveBeenCalledWith(2)
+  })
+
+  it("conditions step button shows a count badge when predicates are present", () => {
+    setMocks(
+      {
+        predicates: {
+          predicates: [
+            { type: "attr" },
+            { type: "attr" },
+            { type: "attr" },
+          ],
+        },
+      },
+      { activeStep: 0 },
+    )
+    render(<TriggerBuilderModal />)
+    const condBtn = screen.getByRole("button", { name: /conditions/i })
+    // The badge shows the count "3" inside the conditions button
+    expect(condBtn.textContent).toContain("3")
+  })
+
+  it("actions step button shows a count badge when actions are present", () => {
+    setMocks({ actions: [{ type: "notify" }, { type: "webhook" }] })
+    render(<TriggerBuilderModal />)
+    const actBtn = screen.getByRole("button", { name: /actions/i })
+    expect(actBtn.textContent).toContain("2")
+  })
+
+  it("spatial step button shows a count badge when operations are present", () => {
+    setMocks({ operations: [{ operation: "st_within" }] })
+    render(<TriggerBuilderModal />)
+    const spatialBtn = screen.getByRole("button", { name: /spatial/i })
+    expect(spatialBtn.textContent).toContain("1")
+  })
+
+  // -------------------------------------------------------------------------
+  // Step content rendering
+  // -------------------------------------------------------------------------
+
+  it("renders the active step's component (identity step)", () => {
+    setMocks({}, { activeStep: 0, currentStep: { id: "identity", label: "Identity" } })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByTestId("step-identity")).toBeInTheDocument()
+    expect(screen.queryByTestId("step-review")).not.toBeInTheDocument()
+  })
+
+  it("renders the review step when activeStep points to review", () => {
+    setMocks(
+      {},
+      {
+        activeStep: 5,
+        currentStep: { id: "review", label: "Review" },
+        isFirst: false,
+        isLast: true,
+      },
+    )
+    render(<TriggerBuilderModal />)
+    expect(screen.getByTestId("step-review")).toBeInTheDocument()
+    expect(screen.queryByTestId("step-identity")).not.toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Footer navigation
+  // -------------------------------------------------------------------------
+
+  it("hides the Previous button on the first step", () => {
+    setMocks({}, { isFirst: true, isLast: false })
+    render(<TriggerBuilderModal />)
+    expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument()
+  })
+
+  it("shows Previous button on non-first steps and calls goPrev", () => {
+    const goPrev = vi.fn()
+    setMocks({}, { isFirst: false, isLast: false, goPrev, activeStep: 2 })
+    render(<TriggerBuilderModal />)
+    fireEvent.click(screen.getByRole("button", { name: /previous/i }))
+    expect(goPrev).toHaveBeenCalledOnce()
+  })
+
+  it("shows Next button on non-last steps and calls goNext", () => {
+    const goNext = vi.fn()
+    setMocks({}, { isFirst: false, isLast: false, goNext, activeStep: 2 })
+    render(<TriggerBuilderModal />)
+    fireEvent.click(screen.getByRole("button", { name: /next/i }))
+    expect(goNext).toHaveBeenCalledOnce()
+  })
+
+  it("on the last step shows 'Create' instead of Next, and calls handleSave", () => {
+    const handleSave = vi.fn()
+    setMocks(
+      { isEditing: false, handleSave, canSave: true },
+      { isFirst: false, isLast: true, activeStep: 5 },
+    )
+    render(<TriggerBuilderModal />)
+    expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /create/i }))
+    expect(handleSave).toHaveBeenCalledOnce()
+  })
+
+  it("on the last step in edit mode shows 'Update' label", () => {
+    setMocks({ isEditing: true }, { isFirst: false, isLast: true, activeStep: 5 })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument()
+  })
+
+  it("save button is disabled when canSave is false", () => {
+    setMocks(
+      { canSave: false },
+      { isFirst: false, isLast: true, activeStep: 5 },
+    )
+    render(<TriggerBuilderModal />)
+    const create = screen.getByRole("button", { name: /create/i })
+    expect(create).toBeDisabled()
+  })
+
+  it("save button shows 'Saving...' when saving is true", () => {
+    setMocks(
+      { saving: true, canSave: true },
+      { isFirst: false, isLast: true, activeStep: 5 },
+    )
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("button", { name: /saving/i })).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Cancel button
+  // -------------------------------------------------------------------------
+
+  it("Cancel button calls closeTriggerBuilder", () => {
+    const closeTriggerBuilder = vi.fn()
+    setMocks({ closeTriggerBuilder })
+    render(<TriggerBuilderModal />)
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }))
+    expect(closeTriggerBuilder).toHaveBeenCalledOnce()
+  })
+
+  it("Cancel button is disabled while saving", () => {
+    setMocks({ saving: true })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByRole("button", { name: /^cancel$/i })).toBeDisabled()
+  })
+
+  // -------------------------------------------------------------------------
+  // Footer summary chips
+  // -------------------------------------------------------------------------
+
+  it("footer summary shows the trigger type label", () => {
+    setMocks({ triggerType: "dml" })
+    render(<TriggerBuilderModal />)
+    // 'dml' is the value, label in TRIGGER_TYPES is 'DML'
+    expect(screen.getByText("DML")).toBeInTheDocument()
+  })
+
+  it("footer summary shows operation count with correct pluralization", () => {
+    const { rerender } = render(<TriggerBuilderModal />)
+    setMocks({ operations: [{}] })
+    rerender(<TriggerBuilderModal />)
+    expect(screen.getByText("1 op")).toBeInTheDocument()
+
+    setMocks({ operations: [{}, {}, {}] })
+    rerender(<TriggerBuilderModal />)
+    expect(screen.getByText("3 ops")).toBeInTheDocument()
+  })
+
+  it("footer summary shows condition count with correct pluralization", () => {
+    setMocks({ predicates: { predicates: [{}, {}] } })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByText("2 conditions")).toBeInTheDocument()
+  })
+
+  it("footer summary shows action count (singular form)", () => {
+    setMocks({ actions: [{ type: "notify" }] })
+    render(<TriggerBuilderModal />)
+    expect(screen.getByText("1 action")).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Keyboard handlers (ESC + Ctrl+Enter)
+  // -------------------------------------------------------------------------
+
+  it("Escape key closes the modal", () => {
+    const closeTriggerBuilder = vi.fn()
+    setMocks({ closeTriggerBuilder })
+    render(<TriggerBuilderModal />)
+    fireEvent.keyDown(document, { key: "Escape" })
+    expect(closeTriggerBuilder).toHaveBeenCalledOnce()
+  })
+
+  it("Ctrl+Enter on the last step with canSave triggers handleSave", () => {
+    const handleSave = vi.fn()
+    setMocks(
+      { handleSave, canSave: true },
+      { isFirst: false, isLast: true, activeStep: 5 },
+    )
+    render(<TriggerBuilderModal />)
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true })
+    expect(handleSave).toHaveBeenCalledOnce()
+  })
+
+  it("Ctrl+Enter on a non-last step does NOT save", () => {
+    const handleSave = vi.fn()
+    setMocks(
+      { handleSave, canSave: true },
+      { isFirst: false, isLast: false, activeStep: 2 },
+    )
+    render(<TriggerBuilderModal />)
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true })
+    expect(handleSave).not.toHaveBeenCalled()
+  })
+
+  it("Ctrl+Enter when canSave is false does NOT save", () => {
+    const handleSave = vi.fn()
+    setMocks(
+      { handleSave, canSave: false },
+      { isFirst: false, isLast: true, activeStep: 5 },
+    )
+    render(<TriggerBuilderModal />)
+    fireEvent.keyDown(document, { key: "Enter", ctrlKey: true })
+    expect(handleSave).not.toHaveBeenCalled()
+  })
+
+  // -------------------------------------------------------------------------
+  // a11y attributes
+  // -------------------------------------------------------------------------
+
+  it("dialog has role='dialog' + aria-modal + aria-labelledby", () => {
+    setMocks()
+    render(<TriggerBuilderModal />)
+    const dialog = screen.getByRole("dialog")
+    expect(dialog).toHaveAttribute("aria-modal", "true")
+    expect(dialog).toHaveAttribute("aria-labelledby", "trigger-builder-title")
+  })
+
+  // -------------------------------------------------------------------------
+  // Stepper reset on re-open
+  // -------------------------------------------------------------------------
+
+  it("calls stepper.reset when the modal opens (so re-opening starts at step 1)", () => {
+    const reset = vi.fn()
+    setMocks({ triggerBuilderOpen: true }, { reset })
+    render(<TriggerBuilderModal />)
+    expect(reset).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Recovery PR

PRs #18 (TriggerBuilderInline), #19 (NodePropertyPanel) and #20 (TriggerBuilderModal) were stacked on \`test/render-helpers\` (#16). When #16 squash-merged to main, GitHub auto-closed those 3 PRs because their base branch was deleted — but the test files **were not on main**.

This PR cherry-picks the 3 test commits directly onto main as a single recovery branch. Net diff = the 3 new test files, nothing else.

## What's in

| File | Tests | Original PR |
|---|---|---|
| \`src/components/triggers/__tests__/TriggerBuilderInline.test.tsx\` | 21 | #18 |
| \`src/components/nodes/__tests__/NodePropertyPanel.test.tsx\` | 25 | #19 |
| \`src/components/triggers/__tests__/TriggerBuilderModal.test.tsx\` | 37 | #20 |
| **Total new** | **83** | |

## Test plan

\`\`\`bash
pnpm test                 # 338 passed (255 prior on main + 83 new)
pnpm exec tsc --noEmit    # clean
\`\`\`

## Audit P1 #8 / issue #3 — closeable after this merges

8/8 components flagged in the audit memo now have meaningful coverage :

| Component | Tests | Where |
|---|---|---|
| constants.ts | 22 | already on main (#12) |
| CronBuilder | 12 | already on main (#13) |
| ActionEditor | 21 | already on main (#14) |
| shared.tsx | 24 | already on main (#15) |
| renderWithProviders + setupStoreReset | 13 | already on main (#16) |
| PredicateBuilder | 32 | already on main (#17) |
| **TriggerBuilderInline** | **21** | **this PR** |
| **NodePropertyPanel** | **25** | **this PR** |
| **TriggerBuilderModal** | **37** | **this PR** |

After merge, \`gispulse-portal/issues/3\` can close with a comment referencing the 7-PR stack that delivered it.

## Bonus side-effects already on main

- Bug found and fixed in #16 (in-PR amendment) : \`setupStoreReset\` JSON deep-clone wiped zustand action functions ; switched to shallow snapshot with regression test.
- UX quirk pinned in this PR's \`TriggerBuilderInline.test.tsx\` : \`toast.success\` quotes \`name\` un-trimmed in \`TriggerBuilderInline.tsx:143\`. 1-line fix for follow-up.

## Why a single PR vs 3

Cleaner review + matches the original intent (the 3 PRs were always meant to land together as one stack). 3 commits preserved in the history (squash will collapse them — fine for the rolling tracker).