### PR TITLE
feat(api): styles.ts client + tests (#22, v1.5)

### DIFF
--- a/src/__tests__/stylesApi.test.ts
+++ b/src/__tests__/stylesApi.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import {
+  getBreaks,
+  putStyle,
+  importQml,
+  exportQml,
+  classifyMethodToBreaksMethod,
+} from "@/api/styles"
+import type { LayerStyleDef } from "@/types/layerStyle"
+
+const ORIGINAL_FETCH = global.fetch
+const _queue: Response[] = []
+
+function makeResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response
+}
+
+beforeEach(() => {
+  _queue.length = 0
+  global.fetch = vi.fn(async (url: RequestInfo | URL): Promise<Response> => {
+    const u = typeof url === "string" ? url : url.toString()
+    if (u.endsWith("/health")) {
+      return makeResponse({ ok: true })
+    }
+    const next = _queue.shift()
+    if (!next) throw new Error(`No mock response queued for ${u}`)
+    return next
+  }) as typeof fetch
+})
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH
+  vi.restoreAllMocks()
+})
+
+function mockJson(body: unknown, status = 200) {
+  _queue.push(makeResponse(body, status))
+}
+
+function lastNonHealthCall(): [string, RequestInit] {
+  const calls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const u = typeof calls[i][0] === "string" ? calls[i][0] : calls[i][0].toString()
+    if (!u.endsWith("/health")) return calls[i] as [string, RequestInit]
+  }
+  throw new Error("No non-health fetch recorded")
+}
+
+describe("getBreaks", () => {
+  it("POSTs field/method/n_classes and returns parsed result", async () => {
+    mockJson({
+      field: "pop",
+      method: "jenks",
+      n_classes: 5,
+      breaks: [1, 5, 10, 15, 20, 25],
+      labels: ["1 – 5", "5 – 10", "10 – 15", "15 – 20", "20 – 25"],
+    })
+    const res = await getBreaks("ds-1", "parcels", "pop", "jenks", 5)
+    expect(res.breaks).toHaveLength(6)
+    expect(res.labels).toHaveLength(5)
+    const call = lastNonHealthCall()
+    expect(call[0]).toContain("/datasets/ds-1/layers/parcels/breaks")
+    expect(call[1].method).toBe("POST")
+    expect(JSON.parse(call[1].body)).toEqual({
+      field: "pop",
+      method: "jenks",
+      n_classes: 5,
+    })
+  })
+
+  it("defaults to jenks + 5 classes", async () => {
+    mockJson({ field: "x", method: "jenks", n_classes: 5, breaks: [], labels: [] })
+    await getBreaks("ds", "l", "x")
+    const body = JSON.parse(lastNonHealthCall()[1].body as string)
+    expect(body.method).toBe("jenks")
+    expect(body.n_classes).toBe(5)
+  })
+})
+
+describe("putStyle", () => {
+  it("PUTs style_def and normalises 'mixed' geom to polygon", async () => {
+    mockJson({ layer_name: "parcels", qml_size_bytes: 512 })
+    const styleDef: LayerStyleDef = {
+      renderer: "single",
+      symbol: { kind: "fill", color: "#ff0000", opacity: 0.5, strokeColor: "#000", strokeWidth: 1 },
+    }
+    await putStyle("ds-1", "parcels", styleDef, "mixed")
+    const call = lastNonHealthCall()
+    expect(call[1].method).toBe("PUT")
+    const body = JSON.parse(call[1].body)
+    expect(body.layer_name).toBe("parcels")
+    expect(body.geom_type).toBe("polygon")
+    expect(body.style_def.renderer).toBe("single")
+  })
+})
+
+describe("importQml", () => {
+  it("uploads multipart with file + layer_name + geom_type", async () => {
+    mockJson({
+      layer_name: "parcels",
+      style_def: { renderer: "single" },
+      qml_size_bytes: 256,
+    })
+    const file = new File(["<qgis/>"], "fixture.qml", { type: "application/xml" })
+    const res = await importQml("ds-1", "parcels", file, "polygon")
+    expect(res.layer_name).toBe("parcels")
+    expect(res.style_def.renderer).toBe("single")
+    const call = lastNonHealthCall()
+    expect(call[0]).toContain("/datasets/ds-1/styles/import")
+    expect(call[1].method).toBe("POST")
+    expect(call[1].body).toBeInstanceOf(FormData)
+  })
+
+  it("throws on non-2xx response", async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => "Invalid QML",
+      json: async () => ({}),
+    } as Response)
+    const file = new File(["bad"], "bad.qml")
+    await expect(importQml("ds", "l", file)).rejects.toThrow(/400/)
+  })
+})
+
+describe("exportQml", () => {
+  it("returns matching layer's QML as Blob", async () => {
+    mockJson({
+      styles: [
+        { f_table_name: "other", styleQML: "<other/>" },
+        { f_table_name: "parcels", styleQML: "<qgis>parcels</qgis>" },
+      ],
+    })
+    const blob = await exportQml("ds", "parcels")
+    expect(blob).toBeInstanceOf(Blob)
+    expect(await blob.text()).toBe("<qgis>parcels</qgis>")
+  })
+
+  it("throws if layer not found in styles", async () => {
+    mockJson({ styles: [] })
+    await expect(exportQml("ds", "missing")).rejects.toThrow(/No QML style/)
+  })
+})
+
+describe("classifyMethodToBreaksMethod", () => {
+  it("maps natural_breaks to jenks", () => {
+    expect(classifyMethodToBreaksMethod("natural_breaks")).toBe("jenks")
+  })
+  it("preserves quantile / equal_interval / std_dev", () => {
+    expect(classifyMethodToBreaksMethod("quantile")).toBe("quantile")
+    expect(classifyMethodToBreaksMethod("equal_interval")).toBe("equal_interval")
+    expect(classifyMethodToBreaksMethod("std_dev")).toBe("std_dev")
+  })
+})

--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -1,0 +1,128 @@
+/**
+ * api/styles.ts — Layer style API client.
+ *
+ * Wraps v1.5 styling endpoints (imagodata/gispulse#41/#42/#43) and re-exports
+ * the existing /distinct + /stats helpers from api/datasets.ts so style editors
+ * have a single import surface.
+ */
+
+import { request, BASE } from "./request"
+import { getDistinctValues, getFieldStats } from "./datasets"
+import type { LayerStyleDef, ClassifyMethod, GeomFamily } from "@/types/layerStyle"
+
+export type BreaksMethod = "jenks" | "quantile" | "equal_interval" | "std_dev" | "pretty"
+
+export interface BreaksResult {
+  field: string
+  method: BreaksMethod
+  n_classes: number
+  breaks: number[]
+  labels: string[]
+}
+
+export async function getBreaks(
+  datasetId: string,
+  layerName: string,
+  field: string,
+  method: BreaksMethod = "jenks",
+  nClasses = 5,
+): Promise<BreaksResult> {
+  return request<BreaksResult>(
+    `/datasets/${datasetId}/layers/${layerName}/breaks`,
+    {
+      method: "POST",
+      body: JSON.stringify({ field, method, n_classes: nClasses }),
+    },
+  )
+}
+
+export interface PutStyleResult {
+  layer_name: string
+  qml_size_bytes: number
+}
+
+export async function putStyle(
+  datasetId: string,
+  layerName: string,
+  styleDef: LayerStyleDef,
+  geomType: GeomFamily | "polygon" | "point" | "line" = "polygon",
+): Promise<PutStyleResult> {
+  const normalisedGeom = geomType === "mixed" ? "polygon" : geomType
+  return request<PutStyleResult>(`/datasets/${datasetId}/styles`, {
+    method: "PUT",
+    body: JSON.stringify({
+      layer_name: layerName,
+      style_def: styleDef,
+      geom_type: normalisedGeom,
+    }),
+  })
+}
+
+export interface ImportQmlResult {
+  layer_name: string
+  style_def: LayerStyleDef
+  qml_size_bytes: number
+}
+
+export async function importQml(
+  datasetId: string,
+  layerName: string,
+  file: File,
+  geomType: GeomFamily | "polygon" | "point" | "line" = "polygon",
+): Promise<ImportQmlResult> {
+  const normalisedGeom = geomType === "mixed" ? "polygon" : geomType
+  const form = new FormData()
+  form.append("layer_name", layerName)
+  form.append("geom_type", normalisedGeom)
+  form.append("file", file)
+
+  const res = await fetch(`${BASE}/datasets/${datasetId}/styles/import`, {
+    method: "POST",
+    body: form,
+  })
+  if (!res.ok) {
+    const detail = await res.text().catch(() => "")
+    throw new Error(`QML import failed (${res.status}): ${detail}`)
+  }
+  return res.json()
+}
+
+export async function exportQml(
+  datasetId: string,
+  layerName: string,
+  filename?: string,
+): Promise<Blob> {
+  const styles = await request<{ styles: Array<{ f_table_name: string; styleQML: string }> }>(
+    `/datasets/${datasetId}/styles`,
+  )
+  const match = styles.styles.find((s) => s.f_table_name === layerName)
+  if (!match || !match.styleQML) {
+    throw new Error(`No QML style found for layer "${layerName}"`)
+  }
+  const blob = new Blob([match.styleQML], { type: "application/xml" })
+  if (filename && typeof window !== "undefined") {
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a")
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  }
+  return blob
+}
+
+const _CLASSIFY_TO_BREAKS: Record<ClassifyMethod, BreaksMethod> = {
+  equal_interval: "equal_interval",
+  quantile: "quantile",
+  natural_breaks: "jenks",
+  std_dev: "std_dev",
+}
+
+export function classifyMethodToBreaksMethod(m: ClassifyMethod): BreaksMethod {
+  return _CLASSIFY_TO_BREAKS[m]
+}
+
+export { getDistinctValues, getFieldStats }
+export type { DistinctValuesResult, FieldStatsResult } from "./datasets"


### PR DESCRIPTION
## Summary
- Closes #22 — prerequis pour les éditeurs #23-#28
- Wraps the 3 new backend endpoints from imagodata/gispulse#45 (\`/breaks\`, \`PUT /styles\`, \`POST /styles/import\`)
- Re-exports \`getDistinctValues\` + \`getFieldStats\` so style editors have a single import surface
- Adds \`classifyMethodToBreaksMethod()\` helper bridging the \`LayerStyleDef.ClassifyMethod\` ("natural_breaks") and backend \`BreaksMethod\` ("jenks") vocabularies

## Test plan
- [x] \`pnpm vitest run\` — 347 tests pass (9 new in src/__tests__/stylesApi.test.ts)
- [x] \`pnpm tsc --noEmit\` — pass
- [x] Mock pattern : global.fetch with /health passthrough + queue, isolates from real backend

## Follow-ups
- imagodata/gispulse-portal#23 — wire \`getBreaks()\` into GraduatedEditor
- imagodata/gispulse-portal#24 — wire \`getDistinctValues()\` into CategorizedEditor
- imagodata/gispulse-portal#25 — wire \`importQml()\` button
- imagodata/gispulse-portal#26 — wire \`exportQml()\` button