### PR TITLE
feat(style): import/export QML buttons in StyleEditorPanel (#25, #26)

### DIFF
--- a/src/__tests__/StyleEditorPanel.qml.test.tsx
+++ b/src/__tests__/StyleEditorPanel.qml.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * StyleEditorPanel — QML import/export interactions (issues #25, #26).
+ *
+ * Covers:
+ *   - Export button calls api/styles.exportQml() with the filename derived
+ *     from `{datasetName}-{layerName}.qml` (sanitised).
+ *   - Import button click opens the hidden file input.
+ *   - Picking a file with NO custom styleDef applies the returned style_def
+ *     immediately (no overwrite dialog).
+ *   - Picking a file when a custom styleDef IS set surfaces the confirm
+ *     dialog; confirming runs the import, cancelling discards it.
+ *   - Toast.success / toast.error are wired on success / failure.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    message: vi.fn(),
+  },
+}))
+
+vi.mock("@/api/styles", () => ({
+  importQml: vi.fn(),
+  exportQml: vi.fn(),
+}))
+
+import { toast } from "sonner"
+import { importQml, exportQml } from "@/api/styles"
+import { StyleEditorPanel } from "@/components/style/StyleEditorPanel"
+import { useDatasetStore } from "@/stores/datasetStore"
+import { useMapViewStore } from "@/stores/mapViewStore"
+import { setupStoreReset } from "@/__tests__/helpers/zustand"
+import { renderWithProviders } from "@/__tests__/helpers/renderWithProviders"
+import type { LayerStyleDef } from "@/types/layerStyle"
+import type { DatasetMeta } from "@/types/dataset"
+
+const DATASET_ID = "ds-1"
+const LAYER_NAME = "parcels"
+const LAYER_KEY = `${DATASET_ID}::${LAYER_NAME}`
+
+function seedStores(opts: { withCustomStyleDef?: boolean } = {}) {
+  const dataset: DatasetMeta = {
+    id: DATASET_ID,
+    name: "Cadastre 2024",
+    source_path: "/tmp/cadastre.gpkg",
+    format: "gpkg",
+    crs: "EPSG:4326",
+    file_size: 1024,
+    layers: [
+      {
+        name: LAYER_NAME,
+        geometry_type: "MultiPolygon",
+        feature_count: 100,
+        bbox: [0, 0, 1, 1],
+        crs: "EPSG:4326",
+        fields: [{ name: "id", type: "int" }],
+      },
+    ],
+    created_at: "2026-04-30",
+  }
+  useDatasetStore.setState({ datasets: [dataset] })
+
+  const styleDef: LayerStyleDef | undefined = opts.withCustomStyleDef
+    ? { renderer: "single", symbol: { kind: "fill", color: "#ff0000", opacity: 0.5, strokeColor: "#000", strokeWidth: 1 } }
+    : undefined
+
+  const view = useMapViewStore.getState().views[0]
+  useMapViewStore.setState({
+    views: [
+      {
+        ...view,
+        state: {
+          ...view.state,
+          layerStack: [
+            {
+              key: LAYER_KEY,
+              visible: true,
+              color: "#3b82f6",
+              opacity: 0.7,
+              displayName: LAYER_NAME,
+              ...(styleDef ? { styleDef } : {}),
+            },
+          ],
+        },
+      },
+    ],
+  })
+}
+
+describe("StyleEditorPanel — QML import/export", () => {
+  setupStoreReset(useDatasetStore, useMapViewStore)
+
+  beforeEach(() => {
+    vi.mocked(toast.success).mockClear()
+    vi.mocked(toast.error).mockClear()
+    vi.mocked(importQml).mockReset()
+    vi.mocked(exportQml).mockReset()
+  })
+
+  it("renders Import .qml + Export .qml buttons in the header", () => {
+    seedStores()
+    renderWithProviders(<StyleEditorPanel layerKey={LAYER_KEY} onClose={vi.fn()} />)
+    expect(screen.getByRole("button", { name: /import \.qml/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /export \.qml/i })).toBeInTheDocument()
+  })
+
+  it("export button calls exportQml with sanitised filename and toasts success", async () => {
+    seedStores()
+    vi.mocked(exportQml).mockResolvedValueOnce(new Blob(["<qgis/>"]))
+    renderWithProviders(<StyleEditorPanel layerKey={LAYER_KEY} onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /export \.qml/i }))
+
+    await waitFor(() => {
+      expect(exportQml).toHaveBeenCalledWith(
+        DATASET_ID,
+        LAYER_NAME,
+        "Cadastre_2024-parcels.qml",
+      )
+    })
+    expect(toast.success).toHaveBeenCalled()
+  })
+
+  it("export button toasts error on failure", async () => {
+    seedStores()
+    vi.mocked(exportQml).mockRejectedValueOnce(new Error("No QML style for layer"))
+    renderWithProviders(<StyleEditorPanel layerKey={LAYER_KEY} onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /export \.qml/i }))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled()
+    })
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it("file pick with no custom styleDef calls importQml directly and applies result", async () => {
+    seedStores({ withCustomStyleDef: false })
+    const returnedStyle: LayerStyleDef = {
+      renderer: "single",
+      symbol: { kind: "fill", color: "#00ff00", opacity: 0.8, strokeColor: "#000", strokeWidth: 1 },
+    }
+    vi.mocked(importQml).mockResolvedValueOnce({
+      layer_name: LAYER_NAME,
+      style_def: returnedStyle,
+      qml_size_bytes: 256,
+    })
+
+    const { container } = renderWithProviders(
+      <StyleEditorPanel layerKey={LAYER_KEY} onClose={vi.fn()} />,
+    )
+
+    const file = new File(["<qgis/>"], "fixture.qml", { type: "application/xml" })
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    expect(input).toBeTruthy()
+
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(importQml).toHaveBeenCalledWith(DATASET_ID, LAYER_NAME, file, "polygon")
+    })
+
+    // confirm the returned style_def landed in the store
+    const stored = useMapViewStore.getState().views[0].state.layerStack[0].styleDef
+    expect(stored).toEqual(returnedStyle)
+    expect(toast.success).toHaveBeenCalled()
+  })
+
+  it("file pick with existing custom styleDef opens overwrite dialog; confirm runs import", async () => {
+    seedStores({ withCustomStyleDef: true })
+    const returnedStyle: LayerStyleDef = { renderer: "single" }
+    vi.mocked(importQml).mockResolvedValueOnce({
+      layer_name: LAYER_NAME,
+      style_def: returnedStyle,
+      qml_size_bytes: 128,
+    })
+
+    const { container } = renderWithProviders(
+      <StyleEditorPanel layerKey={LAYER_KEY} onClose={vi.fn()} />,
+    )
+
+    const file = new File(["<qgis/>"], "fixture.qml", { type: "application/xml" })
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    // Dialog visible, import not yet called
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument()
+    expect(importQml).not.toHaveBeenCalled()
+
+    // Confirm
+    fireEvent.click(screen.getByRole("button", { name: /^replace$/i }))
+
+    await waitFor(() => {
+      expect(importQml).toHaveBeenCalledWith(DATASET_ID, LAYER_NAME, file, "polygon")
+    })
+  })
+
+  it("cancelling the overwrite dialog discards the pending file", async () => {
+    seedStores({ withCustomStyleDef: true })
+    const { container } = renderWithProviders(
+      <StyleEditorPanel layerKey={LAYER_KEY} onClose={vi.fn()} />,
+    )
+
+    const file = new File(["<qgis/>"], "fixture.qml", { type: "application/xml" })
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    expect(await screen.findByRole("alertdialog")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+    })
+    expect(importQml).not.toHaveBeenCalled()
+  })
+
+  it("import failure surfaces toast.error", async () => {
+    seedStores({ withCustomStyleDef: false })
+    vi.mocked(importQml).mockRejectedValueOnce(new Error("Invalid QML"))
+
+    const { container } = renderWithProviders(
+      <StyleEditorPanel layerKey={LAYER_KEY} onClose={vi.fn()} />,
+    )
+
+    const file = new File(["bad"], "bad.qml", { type: "application/xml" })
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement
+    fireEvent.change(input, { target: { files: [file] } })
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled()
+    })
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/style/StyleEditorPanel.tsx
+++ b/src/components/style/StyleEditorPanel.tsx
@@ -6,11 +6,15 @@
  * Changes apply in real-time to the map via the mapViewStore.
  */
 
-import { useCallback, useMemo } from "react"
-import { X, Circle, Minus, Square, Layers, BookOpen, RotateCcw } from "lucide-react"
+import { useCallback, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
+import { X, Circle, Minus, Square, Layers, BookOpen, RotateCcw, Upload, Download } from "lucide-react"
 import { IconButton } from "@/components/ui/icon-button"
+import { ConfirmDialog } from "@/components/ConfirmDialog"
+import { useT } from "@/i18n/useT"
 import { useMapViewStore, parseLayerKey } from "@/stores/mapViewStore"
 import { useDatasetStore } from "@/stores/datasetStore"
+import { importQml, exportQml } from "@/api/styles"
 import type {
   LayerStyleDef,
   RendererType,
@@ -69,6 +73,11 @@ export function StyleEditorPanel({ layerKey, onClose }: StyleEditorPanelProps) {
     const view = s.views.find((v) => v.id === s.activeViewId) ?? s.views[0]
     return view?.state.layerStack ?? []
   })
+  const t = useT()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [pendingImport, setPendingImport] = useState<File | null>(null)
+  const [importing, setImporting] = useState(false)
+  const [exporting, setExporting] = useState(false)
 
   // Find layer metadata and current style
   const ds = datasets.find((d) => d.id === datasetId)
@@ -136,6 +145,55 @@ export function StyleEditorPanel({ layerKey, onClose }: StyleEditorPanelProps) {
     [commit],
   )
 
+  // ── QML import/export ─────────────────────────────────────────────
+
+  const runImport = useCallback(
+    async (file: File) => {
+      setImporting(true)
+      try {
+        const result = await importQml(datasetId, layerName, file, geom)
+        setLayerStyleDef(layerKey, result.style_def)
+        toast.success(t("toast.qml_imported"), { description: file.name })
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err)
+        toast.error(t("toast.qml_import_failed"), { description: detail })
+      } finally {
+        setImporting(false)
+      }
+    },
+    [datasetId, layerName, geom, layerKey, setLayerStyleDef, t],
+  )
+
+  const handleFilePicked = useCallback(
+    (file: File | null) => {
+      if (!file) return
+      // Only show overwrite confirmation when the user already has a custom
+      // style applied. fromLegacyStyle output is just default colour values,
+      // not a deliberate styling choice — overwriting that is harmless.
+      if (mapLayer?.styleDef) {
+        setPendingImport(file)
+      } else {
+        void runImport(file)
+      }
+    },
+    [mapLayer?.styleDef, runImport],
+  )
+
+  const handleExport = useCallback(async () => {
+    setExporting(true)
+    try {
+      const safeDataset = (ds?.name ?? datasetId).replace(/[^a-z0-9_-]+/gi, "_")
+      const safeLayer = layerName.replace(/[^a-z0-9_-]+/gi, "_")
+      await exportQml(datasetId, layerName, `${safeDataset}-${safeLayer}.qml`)
+      toast.success(t("toast.qml_exported"))
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err)
+      toast.error(t("toast.qml_export_failed"), { description: detail })
+    } finally {
+      setExporting(false)
+    }
+  }, [ds, datasetId, layerName, t])
+
   if (!ds || !layerMeta || !mapLayer) return null
 
   const displayName = mapLayer.displayName || layerName
@@ -149,6 +207,32 @@ export function StyleEditorPanel({ layerKey, onClose }: StyleEditorPanelProps) {
           {displayName}
         </span>
         <span className="text-label-sm text-muted-foreground capitalize">{geom}</span>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".qml,application/xml,text/xml"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0] ?? null
+            handleFilePicked(file)
+            // reset so re-selecting the same file still triggers onChange
+            e.target.value = ""
+          }}
+        />
+        <IconButton
+          label={t("style.import_qml")}
+          disabled={importing}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Upload size={12} />
+        </IconButton>
+        <IconButton
+          label={t("style.export_qml")}
+          disabled={exporting}
+          onClick={handleExport}
+        >
+          <Download size={12} />
+        </IconButton>
         <IconButton
           label="Reset to default style"
           onClick={() => { clearLayerStyleDef(layerKey); onClose() }}
@@ -159,6 +243,21 @@ export function StyleEditorPanel({ layerKey, onClose }: StyleEditorPanelProps) {
           <X size={14} />
         </IconButton>
       </div>
+
+      <ConfirmDialog
+        open={pendingImport !== null}
+        title={t("dialog.import_qml.title")}
+        description={t("dialog.import_qml.body")}
+        confirmLabel={t("dialog.import_qml.confirm")}
+        cancelLabel={t("common.cancel")}
+        variant="destructive"
+        onConfirm={() => {
+          const file = pendingImport
+          setPendingImport(null)
+          if (file) void runImport(file)
+        }}
+        onCancel={() => setPendingImport(null)}
+      />
 
       {/* Renderer selector */}
       <div className="flex gap-0.5 px-3 py-1.5 border-b">

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -55,6 +55,20 @@ export const STRINGS = {
   "toast.saved": { en: "Saved", fr: "Enregistré" },
   "toast.copied_clipboard": { en: "Copied to clipboard", fr: "Copié dans le presse-papiers" },
   "toast.deleted": { en: "Deleted", fr: "Supprimé" },
+  "toast.qml_imported": { en: "QML style applied", fr: "Style QML appliqué" },
+  "toast.qml_exported": { en: "QML style downloaded", fr: "Style QML téléchargé" },
+  "toast.qml_import_failed": { en: "QML import failed", fr: "Échec de l'import QML" },
+  "toast.qml_export_failed": { en: "QML export failed", fr: "Échec de l'export QML" },
+
+  // ─── Style editor (QML import/export) ─────────────────────────────────────
+  "style.import_qml": { en: "Import .qml", fr: "Importer .qml" },
+  "style.export_qml": { en: "Export .qml", fr: "Exporter .qml" },
+  "dialog.import_qml.title": { en: "Replace current style?", fr: "Remplacer le style actuel ?" },
+  "dialog.import_qml.body": {
+    en: "Importing this QML file will overwrite the current layer style. Continue?",
+    fr: "Importer ce fichier QML écrasera le style actuel du layer. Continuer ?",
+  },
+  "dialog.import_qml.confirm": { en: "Replace", fr: "Remplacer" },
 
   // ─── Node property panel ──────────────────────────────────────────────────
   "node.properties.parameters_heading": { en: "Parameters", fr: "Paramètres" },


### PR DESCRIPTION
## Summary

PR-1 of the **Train 2 — v1.5 QML-grade styling** stack. Wires the v1.5 styling API (`importQml` / `exportQml` from [`api/styles.ts`](src/api/styles.ts), shipped in #29) to the layer style panel.

- **Import .qml** opens a hidden file picker, uploads the QML to `POST /datasets/{id}/styles/import`, and applies the returned `style_def` via `setLayerStyleDef`. When the layer already carries a custom `styleDef`, a `ConfirmDialog` ("Replace current style?") gates the overwrite so users don't lose work silently. When the layer is still on the default colour scaffold, the import is direct.
- **Export .qml** calls `exportQml(datasetId, layerName, "{datasetName}-{layerName}.qml")`, which fetches the persisted QML from `GET /datasets/{id}/styles` and triggers a browser download. Filenames are sanitised (`/[^a-z0-9_-]+/gi → "_"`).
- Both flows surface success / failure via `sonner` toasts. Six new i18n keys (FR / EN) cover the button labels, dialog copy, and toast messages.

## Closes

- Closes imagodata/gispulse-portal#25 — Import .qml button
- Closes imagodata/gispulse-portal#26 — Export .qml button
- Part of imagodata/gispulse#40 — EPIC v1.5 QML-grade styling

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — succeeds
- [x] `pnpm vitest run src/__tests__/StyleEditorPanel.qml.test.tsx` — 7/7 new cases pass:
  - renders Import / Export buttons in header
  - export uses sanitised `{ds}-{layer}.qml` filename + toasts success
  - export toasts error on backend failure
  - file pick on default-style layer skips dialog and applies returned style_def
  - file pick on customised layer surfaces overwrite dialog; confirm runs import
  - cancelling the dialog discards the pending file (no API call)
  - import failure surfaces `toast.error`
- [x] Full suite: **354 / 354 vitest cases passing**, no regressions.
- [ ] Manual : import QML fixtures from imagodata/gispulse#46 (`categorized_polygon.qml`, `graduated_point_jenks.qml`, …) and round-trip via Export → re-Import in a fresh layer (E2E playwright deferred to a follow-up if useful).

## Stack

PR-1 of 4 on the v1.5 portal frontend train. Next up: PR-2 = #23 + #24 (GraduatedEditor server-breaks + histogram, CategorizedEditor /distinct auto-fill + cap 12 + "Other" bucket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)