### PR TITLE
chore(styles): allow "manual" classify method (types only)

### DIFF
--- a/src/__tests__/stylesApi.test.ts
+++ b/src/__tests__/stylesApi.test.ts
@@ -156,4 +156,7 @@ describe("classifyMethodToBreaksMethod", () => {
     expect(classifyMethodToBreaksMethod("equal_interval")).toBe("equal_interval")
     expect(classifyMethodToBreaksMethod("std_dev")).toBe("std_dev")
   })
+  it("returns null for 'manual' so callers skip the /breaks request", () => {
+    expect(classifyMethodToBreaksMethod("manual")).toBeNull()
+  })
 })

--- a/src/api/styles.ts
+++ b/src/api/styles.ts
@@ -113,15 +113,21 @@ export async function exportQml(
   return blob
 }
 
-const _CLASSIFY_TO_BREAKS: Record<ClassifyMethod, BreaksMethod> = {
+const _CLASSIFY_TO_BREAKS: Partial<Record<ClassifyMethod, BreaksMethod>> = {
   equal_interval: "equal_interval",
   quantile: "quantile",
   natural_breaks: "jenks",
   std_dev: "std_dev",
 }
 
-export function classifyMethodToBreaksMethod(m: ClassifyMethod): BreaksMethod {
-  return _CLASSIFY_TO_BREAKS[m]
+/**
+ * Map a UI ClassifyMethod to the backend `/breaks` endpoint method.
+ *
+ * Returns `null` for `"manual"`, which signals the caller that no server
+ * request should be issued — the breaks were edited by hand.
+ */
+export function classifyMethodToBreaksMethod(m: ClassifyMethod): BreaksMethod | null {
+  return _CLASSIFY_TO_BREAKS[m] ?? null
 }
 
 export { getDistinctValues, getFieldStats }

--- a/src/types/layerStyle.ts
+++ b/src/types/layerStyle.ts
@@ -103,7 +103,7 @@ export interface GraduatedEntry {
   symbol: SymbolDef
 }
 
-export type ClassifyMethod = "equal_interval" | "quantile" | "natural_breaks" | "std_dev"
+export type ClassifyMethod = "equal_interval" | "quantile" | "natural_breaks" | "std_dev" | "manual"
 
 /** One rule in a rule-based renderer */
 export interface RuleEntry {


### PR DESCRIPTION
## Summary
- Extend `ClassifyMethod` with `"manual"` so the graduated editor can represent user-edited breaks.
- Make `classifyMethodToBreaksMethod()` return `null` for `"manual"` — a signal to callers that no `/breaks` request should be issued.
- Foundation only — UI wiring (METHODS dropdown entry, editable break bounds, `computeBreaks` handling) lands in a follow-up PR.

## Test plan
- [x] `pnpm test --run` — 348/348 passing (added 1 test for null return)
- [x] `pnpm exec tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)