### PR TITLE
fix(tsconfig): remove deprecated baseUrl

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -7,7 +7,6 @@
     "module": "ESNext",
     "types": ["vite/client"],
     "skipLibCheck": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- TypeScript 6 deprecates `baseUrl`; TS 7 will remove it. CI `frontend` job currently fails on every PR with TS5101.
- Drop `baseUrl: "."` from `tsconfig.json` and `tsconfig.app.json`. Since TS 5.0, `paths` resolves relative to the tsconfig file, so this is a no-op for module resolution.

## Test plan
- [x] `pnpm exec tsc --noEmit` — clean locally
- [ ] CI `frontend` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)