### PR TITLE
feat(packaging): publish gispulse-portal as PyPI wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build + smoke-test only; skip PyPI publish and GH Release."
+        type: boolean
+        default: true
+      version:
+        description: "Version to dry-run against (defaults to pyproject.toml)."
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  PYTHON_VERSION: "3.12"
+  NODE_VERSION: "22"
+  PNPM_VERSION: "10"
+  # ``python -m build`` uses an outdir distinct from ``./dist`` because
+  # ``./dist`` is owned by Vite (SPA build output) and feeding it back
+  # to setuptools would mix the wheel with the static assets.
+  PY_DIST_DIR: "python-dist"
+
+jobs:
+  # ── 1. Build SPA + Python wheel/sdist, publish to PyPI ──────────────
+  publish-pypi:
+    name: Publish gispulse-portal to PyPI
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # ── Frontend build (SPA) ────────────────────────────────────
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install JS dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SPA (pnpm build → ./dist)
+        run: pnpm build
+
+      - name: Embed SPA build into Python package
+        # The wheel ships the SPA via [tool.setuptools.package-data].
+        # This step is the bridge between the JS toolchain output
+        # (./dist) and the Python module location (gispulse_portal/dist).
+        run: |
+          rm -rf gispulse_portal/dist
+          cp -r dist gispulse_portal/dist
+          echo "Bundled SPA size:"
+          du -sh gispulse_portal/dist
+          echo "Top-level entries:"
+          ls -la gispulse_portal/dist | head -20
+
+      # ── Python build ────────────────────────────────────────────
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Python build tooling
+        run: pip install build twine
+
+      - name: Verify version matches tag
+        if: github.event_name == 'push'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PYPROJECT_VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.*)"/\1/')
+          INIT_VERSION=$(grep -E '^__version__ = ' gispulse_portal/__init__.py | head -1 | sed -E 's/__version__ = "(.*)"/\1/')
+          echo "Tag: $TAG_VERSION"
+          echo "pyproject.toml: $PYPROJECT_VERSION"
+          echo "gispulse_portal/__init__.py: $INIT_VERSION"
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "ERROR: tag and pyproject.toml versions differ"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" != "$INIT_VERSION" ]; then
+            echo "ERROR: tag and __init__.py __version__ differ"
+            exit 1
+          fi
+
+      - name: Build sdist + wheel
+        run: python -m build --outdir "${PY_DIST_DIR}"
+
+      - name: Verify package metadata
+        run: twine check "${PY_DIST_DIR}"/*
+
+      - name: List built artifacts
+        run: ls -la "${PY_DIST_DIR}/"
+
+      - name: Smoke-test wheel in clean venv
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --upgrade pip
+          /tmp/smoke/bin/pip install "${PY_DIST_DIR}"/gispulse_portal-*.whl
+          /tmp/smoke/bin/python -c "
+          from gispulse_portal import PORTAL_DIST_PATH, __version__
+          print(f'gispulse_portal {__version__} -> {PORTAL_DIST_PATH}')
+          assert PORTAL_DIST_PATH.is_dir(), f'dist missing at {PORTAL_DIST_PATH}'
+          assert (PORTAL_DIST_PATH / 'index.html').is_file(), 'index.html missing'
+          print('smoke ok')
+          "
+          /tmp/smoke/bin/pip install pytest
+          /tmp/smoke/bin/pytest tests/ -v
+
+      - name: Publish to PyPI (trusted publisher OIDC)
+        if: github.event_name == 'push' || inputs.dry_run == false
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ${{ env.PY_DIST_DIR }}
+
+  # ── 2. Create GitHub Release with sdist + wheel attached ────────────
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || inputs.dry_run == false
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Re-build artifacts here (needs same SPA bundling as publish-pypi).
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: |
+          rm -rf gispulse_portal/dist
+          cp -r dist gispulse_portal/dist
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Build artifacts
+        run: |
+          pip install build
+          python -m build --outdir "${PY_DIST_DIR}"
+
+      - name: Generate checksums
+        run: |
+          cd "${PY_DIST_DIR}"
+          sha256sum *.whl *.tar.gz > SHA256SUMS
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "GISPulse Portal ${{ github.ref_name }}" \
+            --generate-notes \
+            "${PY_DIST_DIR}"/*.whl "${PY_DIST_DIR}"/*.tar.gz "${PY_DIST_DIR}"/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,16 @@ dist
 dist-ssr
 *.local
 
+# Python packaging artifacts
+gispulse_portal/dist/
+python-dist/
+build/
+*.egg-info/
+__pycache__/
+*.pyc
+.venv/
+.pytest_cache/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -25,7 +25,28 @@ React + Vite + TailwindCSS portal — the public, AGPL-licensed companion to the
 These are extended at app composition time when `gispulse-portal-pro` is
 installed alongside this package.
 
-## Install / dev
+## Install paths
+
+This repo dual-publishes. Pick the install path that fits your workflow:
+
+| Install                      | What you get                                                      | Typical user                          |
+|------------------------------|-------------------------------------------------------------------|---------------------------------------|
+| `pip install gispulse`       | CLI + runtime ESB + API only (no UI)                              | servers, CI/CD, headless, power users |
+| `pip install gispulse-portal`| Same as above **plus** the bundled SPA, served same-origin        | users who want the local workbench    |
+| Hosted SPA on GH Pages       | Marketing site + Try-it demo against `demo.gispulse.dev` backend  | drive-by visitors                     |
+
+The PyPI wheel ships the pre-built SPA inside the Python package and exposes it via:
+
+```python
+from gispulse_portal import PORTAL_DIST_PATH
+# -> Path to the bundled SPA, ready to mount with FastAPI StaticFiles
+```
+
+The `gispulse portal` CLI command (in the `gispulse` package) detects
+`gispulse_portal` and mounts it at `/portal` automatically. If the package is
+not installed, it prints a helpful install hint instead of failing.
+
+## Frontend dev
 
 ```bash
 pnpm install
@@ -33,8 +54,6 @@ pnpm dev      # → http://localhost:5173
 pnpm build    # → ./dist
 pnpm test
 ```
-
-## Backend
 
 By default the portal expects the engine at `http://localhost:8000`.
 Override with `VITE_API_BASE_URL` env var.
@@ -44,6 +63,55 @@ Override with `VITE_API_BASE_URL` env var.
 pip install gispulse[postgis,api,raster,network]
 uvicorn gispulse.adapters.http.app:create_app --factory --port 8000
 ```
+
+## Build & publish (maintainers)
+
+This repo dual-publishes on every `v*.*.*` tag:
+
+1. **GH Pages SPA** — `deploy.yml` runs on every `main` push, builds via
+   `pnpm build`, and force-pushes the result to the `deploy` branch (served
+   by GitHub Pages).
+2. **PyPI wheel** — `release.yml` runs on tag push:
+   - `pnpm install && pnpm build` (produces `./dist`)
+   - copies `./dist` → `gispulse_portal/dist/` (so it gets included as
+     `package_data`)
+   - `python -m build --outdir python-dist` (produces wheel + sdist)
+   - smoke-tests the wheel in a clean venv
+   - publishes to PyPI via [trusted publisher
+     (OIDC)](https://docs.pypi.org/trusted-publishers/) — no token in repo
+
+### Local wheel build
+
+```bash
+pnpm install
+pnpm build
+rm -rf gispulse_portal/dist
+cp -r dist gispulse_portal/dist
+python -m build --outdir python-dist
+ls -la python-dist/
+# gispulse_portal-1.5.1-py3-none-any.whl
+# gispulse_portal-1.5.1.tar.gz
+```
+
+### Local install smoke test
+
+```bash
+python -m venv /tmp/smoke && /tmp/smoke/bin/pip install --upgrade pip
+/tmp/smoke/bin/pip install python-dist/gispulse_portal-*.whl
+/tmp/smoke/bin/python -c "
+from gispulse_portal import PORTAL_DIST_PATH
+print(PORTAL_DIST_PATH)
+assert PORTAL_DIST_PATH.is_dir()
+assert (PORTAL_DIST_PATH / 'index.html').is_file()
+print('ok')
+"
+```
+
+### Version policy
+
+The git tag is the single source of truth. The release workflow asserts that
+the tag, `pyproject.toml`, and `gispulse_portal/__init__.py` `__version__`
+all match before publishing — a mismatch fails the build.
 
 ## License
 

--- a/gispulse_portal/__init__.py
+++ b/gispulse_portal/__init__.py
@@ -1,0 +1,46 @@
+"""GISPulse Portal — bundled SPA for offline / same-origin local serving.
+
+This package ships the pre-built VitePress / Vite SPA (the ``dist/``
+directory at install time) so that the ``gispulse`` CLI can mount it
+via FastAPI ``StaticFiles`` on ``localhost`` without depending on a
+live network deployment.
+
+Usage from ``gispulse``::
+
+    from gispulse_portal import PORTAL_DIST_PATH
+    app.mount("/portal", StaticFiles(directory=str(PORTAL_DIST_PATH), html=True))
+
+The package contains no runtime logic — it is a pure assets carrier.
+The version is kept in lockstep with the git tag and the upstream
+``gispulse`` runtime via :data:`__version__`.
+"""
+
+from __future__ import annotations
+
+from importlib.resources import files
+from pathlib import Path
+
+__all__ = ["PORTAL_DIST_PATH", "__version__"]
+
+# Single source of truth for the package version. Bumped by the
+# release workflow before ``python -m build`` runs (see
+# ``.github/workflows/release.yml``).
+__version__ = "1.5.1"
+
+
+def _resolve_dist_path() -> Path:
+    """Return the on-disk path to the bundled SPA build.
+
+    Uses :func:`importlib.resources.files` so the lookup works both
+    when the package is installed as a wheel (zip-safe-friendly) and
+    when running from a source checkout.
+    """
+    resource = files(__name__).joinpath("dist")
+    # ``files()`` returns a Traversable. For ``StaticFiles`` we need
+    # a real filesystem path; both wheels and editable installs of
+    # this package satisfy that since ``dist/`` is shipped as
+    # package_data.
+    return Path(str(resource))
+
+
+PORTAL_DIST_PATH: Path = _resolve_dist_path()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gispulse-portal"
+version = "1.5.1"
+description = "Pre-built web UI for GISPulse — ships the SPA so `gispulse portal` can serve it same-origin on localhost."
+license = "AGPL-3.0-or-later"
+requires-python = ">=3.10"
+readme = "README.md"
+authors = [
+    {name = "ImagoData", email = "contact@imagodata.com"},
+]
+keywords = ["gis", "geospatial", "ui", "portal", "spa", "gispulse"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: GIS",
+    "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
+    "Operating System :: OS Independent",
+    "Framework :: FastAPI",
+]
+dependencies = [
+    # The portal is meaningful only alongside the gispulse engine.
+    # Lockstep version bump keeps the SPA <-> backend contract honest.
+    "gispulse>=1.5.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "build>=1.0,<2.0",
+    "pytest>=9.0,<10.0",
+]
+
+[project.urls]
+Homepage = "https://gispulse.dev"
+Documentation = "https://docs.gispulse.dev"
+Repository = "https://github.com/imagodata/gispulse-portal"
+Issues = "https://github.com/imagodata/gispulse-portal/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["gispulse_portal*"]
+exclude = ["tests*", "node_modules*", "src*", "public*", "dist*"]
+
+[tool.setuptools.package-data]
+# Ship the entire built SPA tree as package data. The ``release.yml``
+# workflow copies the ``./dist`` produced by ``pnpm build`` into
+# ``gispulse_portal/dist`` before invoking ``python -m build``.
+gispulse_portal = ["dist/**/*", "dist/*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for the ``gispulse_portal`` PyPI package."""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,75 @@
+"""Smoke tests guarding the PyPI wheel contract.
+
+These tests verify that the bundled SPA build is shipped with the
+package (otherwise ``gispulse portal`` would mount an empty
+``StaticFiles`` directory at runtime, which is the most common
+silent-bug failure mode for this kind of "carrier" package).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_package_imports() -> None:
+    """The package must be importable without side effects."""
+    import gispulse_portal  # noqa: F401
+
+
+def test_version_is_pep440_string() -> None:
+    """``__version__`` must be a non-empty string usable by setuptools."""
+    from gispulse_portal import __version__
+
+    assert isinstance(__version__, str)
+    assert __version__
+    # crude PEP440 sanity (digits + dots, optional pre/post/dev)
+    assert __version__[0].isdigit(), f"unexpected version prefix: {__version__!r}"
+
+
+def test_portal_dist_path_exists() -> None:
+    """The bundled ``dist/`` directory must be shipped with the wheel.
+
+    This is the critical contract: if this fails post-install, the
+    ``release.yml`` workflow forgot to run ``pnpm build`` and copy
+    the result into ``gispulse_portal/dist`` before ``python -m build``.
+    """
+    from gispulse_portal import PORTAL_DIST_PATH
+
+    assert isinstance(PORTAL_DIST_PATH, Path)
+    if not PORTAL_DIST_PATH.is_dir():
+        pytest.fail(
+            f"Bundled SPA build is missing at {PORTAL_DIST_PATH!s}. "
+            "Run `pnpm build && cp -r dist gispulse_portal/dist` "
+            "before `python -m build`."
+        )
+
+
+def test_portal_dist_contains_index_html() -> None:
+    """The SPA entrypoint must be present (``index.html`` is mandatory
+    for ``StaticFiles(html=True)``)."""
+    from gispulse_portal import PORTAL_DIST_PATH
+
+    index = PORTAL_DIST_PATH / "index.html"
+    if not index.is_file():
+        pytest.fail(
+            f"index.html not found in {PORTAL_DIST_PATH!s}. "
+            "The SPA build is incomplete or the wrong directory was packaged."
+        )
+
+
+def test_portal_dist_contains_assets() -> None:
+    """A non-trivial SPA build must ship at least one JS/CSS asset.
+
+    Defends against shipping an empty dist/ that has only ``index.html``.
+    """
+    from gispulse_portal import PORTAL_DIST_PATH
+
+    assets_dir = PORTAL_DIST_PATH / "assets"
+    if not assets_dir.is_dir():
+        pytest.fail(f"assets/ directory missing in {PORTAL_DIST_PATH!s}")
+
+    # At least one .js file (rolldown/rollup output)
+    js_files = list(assets_dir.glob("*.js"))
+    assert js_files, f"no .js bundles found in {assets_dir!s}"


### PR DESCRIPTION
Closes #35.

## Summary

Transforms `gispulse-portal` into a **dual publisher**:
- GitHub Pages keeps deploying the marketing / Try-it SPA on every push to `main` (`deploy.yml`, untouched).
- On every `v*` tag, `release.yml` now builds a `gispulse-portal` PyPI wheel that ships the pre-built SPA so the `gispulse portal` CLI command (in the `gispulse` repo) can mount it via FastAPI `StaticFiles` on localhost — same-origin, no mixed-content browser dance.

This is the v1.5.1 implementation of the **two-package architecture** decided 2026-04-30: `pip install gispulse` = CLI only, `pip install gispulse-portal` = CLI + UI.

## What's in the diff

| File | Purpose |
|------|---------|
| `pyproject.toml` (new) | setuptools, AGPL-3.0-or-later, depends on `gispulse>=1.5.0`; `[tool.setuptools.package-data]` ships `gispulse_portal/dist/**/*` |
| `gispulse_portal/__init__.py` (new) | exposes `PORTAL_DIST_PATH` (Path to bundled SPA) + `__version__`. Pure assets carrier, no runtime logic. |
| `.github/workflows/release.yml` (new) | tag-driven; pnpm build → embed `dist/` in module → `python -m build --outdir python-dist` (avoids name clash with Vite's `./dist`) → twine check → smoke test in clean venv → publish via PyPI trusted-publisher OIDC, env `pypi` (inherits the 5 min wait_timer policy from the gispulse repo) |
| `tests/test_packaging.py` (new) | 5 tests guarding the wheel contract: import OK, version is PEP-440, `PORTAL_DIST_PATH` is a real dir, `index.html` ships, at least one JS bundle ships |
| `README.md` | install paths matrix, build & publish docs, single-source-of-truth version policy |
| `.gitignore` | adds Python build artifacts (`gispulse_portal/dist/`, `python-dist/`, `__pycache__`, `.pytest_cache`, `*.egg-info`) |
| `__init__.py` (deleted) | legacy 0-byte root file, predates the `gispulse_portal/` module and would have confused setuptools' package discovery |

## Validation (local)

- `pnpm install --frozen-lockfile` — clean
- `pnpm build` — produces `./dist` (same path GH Pages consumes, 3.0 MB)
- `python -m build --outdir python-dist` — produces:
  - `gispulse_portal-1.5.1-py3-none-any.whl` (**893 KB**, 36 SPA assets + `index.html` + `__init__.py`)
  - `gispulse_portal-1.5.1.tar.gz` (sdist, 883 KB)
- `twine check python-dist/*` — both PASSED
- `pytest tests/ -v` — 5/5 green
- `pnpm exec tsc --noEmit` — clean
- `pnpm test` — 347/347 green
- `deploy.yml` GH Pages workflow inspected — unchanged behaviour, no path collision (Vite still owns root `./dist`, the wheel uses `gispulse_portal/dist/` and `python-dist/`)

## Architecture notes

The output-dir collision between Vite (`./dist`) and `python -m build` (default `./dist`) is resolved by passing `--outdir python-dist` to `python -m build`. Documented in the workflow `env:` block and the README.

The version is asserted in three places by the workflow: git tag, `pyproject.toml`, `gispulse_portal/__init__.py:__version__`. Mismatch fails the build before PyPI is hit.

The `gispulse>=1.5.0` runtime dep guarantees that anyone who `pip install gispulse-portal` also pulls a compatible engine. SPA <-> backend contract tracking is honest because the SPA is rebuilt and re-bundled on every release.

## Out of scope (intentionally deferred)

- **Actual PyPI publish** — workflow is wired but the trusted-publisher mapping (PyPI side) needs to be configured by the maintainer once. No tokens hardcoded.
- **`gispulse portal` CLI command** — that's the matching ticket on the `gispulse` repo (#51). It will detect `gispulse_portal` via `importlib`, mount it via `StaticFiles`, and graceful-degrade with an install hint if the package is missing.
- **Other v1.5.1 children** — `#30` (SettingsPanel), `#31` (mode toggle), `#32`/`#33` (docs) all live in their own PRs.

## Test plan

- [ ] Frontend pipeline still green on `main` after merge (`deploy.yml` + `ci.yml`)
- [ ] `release.yml` runs cleanly on a dry-run (`workflow_dispatch` with `dry_run=true`)
- [ ] Configure trusted-publisher on PyPI side: project `gispulse-portal`, repo `imagodata/gispulse-portal`, workflow `release.yml`, env `pypi`
- [ ] Tag `v1.5.1`, verify the workflow ships to PyPI
- [ ] `pip install gispulse-portal` in a clean env → `from gispulse_portal import PORTAL_DIST_PATH; assert PORTAL_DIST_PATH.is_dir()`

## Refs

- Issue #35
- Architecture memory `two_package_architecture_2026_04_30`
- Sprint plan memory `sprint_plan_v15x_2026_04_30`
- PyPI workflow reference: `imagodata/gispulse:.github/workflows/release.yml`