### PR TITLE
feat(portal): wire settingsStore.backendUrl into api/request layer

### DIFF
--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -1,0 +1,191 @@
+/**
+ * request.test — issue #41: settingsStore.backendUrl wiring.
+ *
+ * Asserts the URL composition contract:
+ *   - empty store URL  → fetch hits /api/portal/...  + /health
+ *   - custom store URL → fetch hits {url}/api/portal/...  + {url}/health
+ *   - trailing slash on the stored URL is stripped
+ *   - cache invalidation when the user swaps backends mid-session
+ *   - legacy `BASE` import surface still works under template literals
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import {
+  request,
+  isBackendAlive,
+  getBase,
+  BASE,
+  API_PATH_PREFIX,
+  _resetBackendAliveCache,
+} from "@/api/request"
+import { useSettingsStore } from "@/stores/settingsStore"
+
+function makeOk(body: unknown = {}, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
+  } as Response
+}
+
+function resetStore() {
+  useSettingsStore.setState({
+    backendUrl: "",
+    healthStatus: "idle",
+    healthLatencyMs: null,
+    healthError: null,
+    panelOpen: false,
+    readOnlyDialogOpen: false,
+  })
+}
+
+describe("getBase()", () => {
+  beforeEach(() => resetStore())
+
+  it("returns the proxy default when backendUrl is empty", () => {
+    expect(getBase()).toBe("/api/portal")
+    expect(getBase()).toBe(API_PATH_PREFIX)
+  })
+
+  it("composes {backendUrl}/api/portal when a custom URL is set", () => {
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    expect(getBase()).toBe("http://localhost:8001/api/portal")
+  })
+
+  it("strips a trailing slash from the stored URL", () => {
+    // Direct setState bypasses the validator; getBase() must still
+    // produce a clean URL with no double slash.
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001/" })
+    expect(getBase()).toBe("http://localhost:8001/api/portal")
+  })
+
+  it("honors HTTPS origins (e.g. demo backend)", () => {
+    useSettingsStore.setState({ backendUrl: "https://demo.gispulse.dev" })
+    expect(getBase()).toBe("https://demo.gispulse.dev/api/portal")
+  })
+})
+
+describe("BASE legacy proxy", () => {
+  beforeEach(() => resetStore())
+
+  it("stringifies to the live getBase() result inside template literals", () => {
+    expect(`${BASE}/datasets/upload`).toBe("/api/portal/datasets/upload")
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    expect(`${BASE}/datasets/upload`).toBe(
+      "http://localhost:8001/api/portal/datasets/upload",
+    )
+  })
+
+  it("supports standard string methods (.length, .startsWith)", () => {
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    // String methods get forwarded onto the resolved live string.
+    expect((BASE as unknown as string).startsWith("http://")).toBe(true)
+  })
+})
+
+describe("request() URL composition", () => {
+  const ORIGINAL_FETCH = global.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    resetStore()
+    _resetBackendAliveCache()
+    fetchMock = vi.fn(async (url: RequestInfo | URL): Promise<Response> => {
+      // Auto-respond OK to every call; the assertions check the URL.
+      void url
+      return makeOk({ ok: true })
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH
+    vi.restoreAllMocks()
+  })
+
+  it("hits same-origin /api/portal/... when store is empty", async () => {
+    await request("/datasets")
+    // First call is the /health probe, second is the actual request.
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls).toContain("/health")
+    expect(urls).toContain("/api/portal/datasets")
+  })
+
+  it("hits {backendUrl}/api/portal/... when a custom URL is set", async () => {
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    await request("/projects")
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls).toContain("http://localhost:8001/health")
+    expect(urls).toContain("http://localhost:8001/api/portal/projects")
+  })
+
+  it("re-resolves the URL on every call (live wiring, not cached)", async () => {
+    // First call against the demo backend.
+    await request("/foo")
+    let urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls).toContain("/api/portal/foo")
+
+    // User switches to a custom backend mid-session.
+    useSettingsStore.setState({ backendUrl: "http://my.engine:8001" })
+    _resetBackendAliveCache() // simulate the SettingsPanel commit hook
+    fetchMock.mockClear()
+
+    await request("/bar")
+    urls = fetchMock.mock.calls.map((c) => String(c[0]))
+    expect(urls).toContain("http://my.engine:8001/health")
+    expect(urls).toContain("http://my.engine:8001/api/portal/bar")
+  })
+
+  it("propagates query strings and JSON body without mangling the base", async () => {
+    useSettingsStore.setState({ backendUrl: "https://demo.gispulse.dev" })
+    await request("/sql/preview?limit=10", {
+      method: "POST",
+      body: JSON.stringify({ query: "SELECT 1" }),
+    })
+    const lastCall = fetchMock.mock.calls.find((c) =>
+      String(c[0]).includes("/sql/preview"),
+    )
+    expect(lastCall).toBeDefined()
+    expect(String(lastCall![0])).toBe(
+      "https://demo.gispulse.dev/api/portal/sql/preview?limit=10",
+    )
+    const init = lastCall![1] as RequestInit
+    expect(init.method).toBe("POST")
+    expect(init.body).toBe(JSON.stringify({ query: "SELECT 1" }))
+  })
+})
+
+describe("isBackendAlive() cache invalidation", () => {
+  const ORIGINAL_FETCH = global.fetch
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    resetStore()
+    _resetBackendAliveCache()
+    fetchMock = vi.fn(async (url: RequestInfo | URL): Promise<Response> => {
+      void url
+      return makeOk({ ok: true })
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH
+    vi.restoreAllMocks()
+  })
+
+  it("re-probes /health when the user swaps backends", async () => {
+    // First call: demo (empty) → probes /health
+    await isBackendAlive()
+    expect(fetchMock).toHaveBeenCalledWith("/health", expect.any(Object))
+
+    // User connects to local engine — the next isBackendAlive() must
+    // probe the new origin, not return the cached "alive" from /health.
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    await isBackendAlive()
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8001/health",
+      expect.any(Object),
+    )
+  })
+})

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -2,10 +2,98 @@
  * api/request.ts — Base HTTP request helpers and backend health gate.
  *
  * Issue #194 (A7-S3): extracted from the monolithic client.ts.
- * All domain modules import `request` and `isBackendAlive` from here.
+ * Issue #41   (v1.5.1): wires `useSettingsStore.backendUrl` into the
+ *                       request layer so Mode 2 "Connect your engine"
+ *                       actually swaps origins instead of pretending to.
+ *
+ * Path scheme contract
+ * --------------------
+ * The backend mounts portal routes under `/api/portal/...` (same path
+ * served by `demo.gispulse.dev` and by `gispulse engine` locally). We
+ * keep that suffix invariant — the only thing that changes between
+ * "Demo" and "My engine" is the origin prefix.
+ *
+ *   demo / sentinel  → request("/foo") → fetch("/api/portal/foo")
+ *   custom URL       → request("/foo") → fetch("http://host:port/api/portal/foo")
+ *
+ * The store is intentionally read via `getState()` (Zustand's non-React
+ * accessor) so the request layer stays free of React hooks. Reading at
+ * call-time means a user can switch backends from the SettingsPanel and
+ * the very next API call honors the new URL — no module reload needed.
+ *
+ * Legacy `BASE` export
+ * --------------------
+ * Pre-#41, modules imported a `const BASE = "/api/portal"` and used it
+ * inside their own template literals (`${BASE}/datasets/upload`). To
+ * preserve backwards-compat without a sweeping refactor, `BASE` is now
+ * a getter-backed string-coercible Proxy: any template literal or
+ * concatenation will see the live, store-driven value. New code should
+ * prefer `getBase()`.
  */
 
-export const BASE = "/api/portal"
+import { useSettingsStore } from "@/stores/settingsStore"
+
+/** Suffix appended to the active origin for portal API routes. */
+export const API_PATH_PREFIX = "/api/portal"
+
+/**
+ * Resolve the active API base URL by reading `backendUrl` from the
+ * settings store. Empty / sentinel falls back to a same-origin path so
+ * the dev proxy and the bundled `gispulse portal` static mount keep
+ * working without any user configuration.
+ *
+ * Exposed as a function (not a const) because the value must be read at
+ * each call — the user can switch backends at runtime via the
+ * SettingsPanel and we want the very next request to honor the change.
+ */
+export function getBase(): string {
+  // Defensive: in non-DOM contexts (early SSR-shaped boot, edge cases
+  // during module init) the store may not have hydrated yet. The store
+  // module itself tolerates missing window globals, but calling
+  // `getState()` before the create() factory ran would throw.
+  let backendUrl = ""
+  try {
+    backendUrl = useSettingsStore.getState().backendUrl ?? ""
+  } catch {
+    backendUrl = ""
+  }
+  if (!backendUrl) return API_PATH_PREFIX
+  // `normalizeBackendUrl` already strips trailing slashes when the URL
+  // entered the store, but be defensive against direct setState calls
+  // in tests that bypass the validator.
+  const trimmed = backendUrl.replace(/\/+$/, "")
+  return `${trimmed}${API_PATH_PREFIX}`
+}
+
+/**
+ * Backwards-compat string-coercible proxy. Existing modules import
+ * `BASE` and inline it inside template literals or concatenations:
+ *
+ *   import { BASE } from "./request"
+ *   fetch(`${BASE}/datasets/upload`)
+ *
+ * Migrating those to `getBase()` would be a >10-file diff outside the
+ * scope of #41 (a wiring fix, not a refactor). Instead, `BASE` is a
+ * Proxy whose `Symbol.toPrimitive` / `toString` / `valueOf` traps all
+ * return the live `getBase()` value. Standard string methods like
+ * `.length` / `.startsWith` are forwarded onto the resolved string.
+ *
+ * Caveat: `typeof BASE === "object"` (it's a Proxy), but no consumer
+ * we ship inspects that — they only stringify it.
+ */
+export const BASE: string = new Proxy(
+  Object.create(null) as object,
+  {
+    get(_t, prop) {
+      const live = getBase()
+      if (prop === Symbol.toPrimitive) return () => live
+      if (prop === "toString" || prop === "valueOf") return () => live
+      const target = live as unknown as Record<string | symbol, unknown>
+      const v = target[prop as string]
+      return typeof v === "function" ? (v as (...args: unknown[]) => unknown).bind(live) : v
+    },
+  },
+) as unknown as string
 
 // ---------------------------------------------------------------------------
 // Backend availability gate — avoids network 404 noise when backend is down
@@ -13,10 +101,29 @@ export const BASE = "/api/portal"
 
 let _backendAlive: boolean | null = null
 let _healthPromise: Promise<boolean> | null = null
+/** Last URL probed by `isBackendAlive`; used to invalidate the cache when the user switches backends. */
+let _lastProbedUrl: string | null = null
+
+/**
+ * Compose the /health URL from the active backend URL. Empty /
+ * sentinel hits the same-origin `/health` path served by the dev proxy
+ * or the bundled engine. Custom URL hits `${url}/health` so the
+ * healthcheck reflects the actual target the request layer will use.
+ */
+function getHealthUrl(): string {
+  let backendUrl = ""
+  try {
+    backendUrl = useSettingsStore.getState().backendUrl ?? ""
+  } catch {
+    backendUrl = ""
+  }
+  if (!backendUrl) return "/health"
+  return `${backendUrl.replace(/\/+$/, "")}/health`
+}
 
 async function checkBackend(): Promise<boolean> {
   try {
-    const res = await fetch("/health", { method: "GET" })
+    const res = await fetch(getHealthUrl(), { method: "GET" })
     return res.ok
   } catch {
     return false
@@ -25,6 +132,15 @@ async function checkBackend(): Promise<boolean> {
 
 /** Returns true if backend is reachable. Caches with retry on failure. */
 export function isBackendAlive(): Promise<boolean> {
+  // Invalidate the cache when the user swapped backends so the next
+  // call probes the new origin instead of trusting a stale "alive".
+  const targetUrl = getHealthUrl()
+  if (_lastProbedUrl !== null && _lastProbedUrl !== targetUrl) {
+    _backendAlive = null
+    _healthPromise = null
+  }
+  _lastProbedUrl = targetUrl
+
   if (_backendAlive !== null) return Promise.resolve(_backendAlive)
   if (!_healthPromise) {
     _healthPromise = checkBackend().then((alive) => {
@@ -38,9 +154,21 @@ export function isBackendAlive(): Promise<boolean> {
   return _healthPromise
 }
 
-export async function request<T>(path: string, init?: RequestInit, base = BASE): Promise<T> {
+/**
+ * Reset the cached backend-alive state. Exposed for tests and for the
+ * SettingsPanel "Switch backend" flow that wants the next call to
+ * actually probe the new origin instead of trusting a stale result.
+ */
+export function _resetBackendAliveCache(): void {
+  _backendAlive = null
+  _healthPromise = null
+  _lastProbedUrl = null
+}
+
+export async function request<T>(path: string, init?: RequestInit, base?: string): Promise<T> {
   if (!(await isBackendAlive())) throw new Error("Backend unavailable")
-  const res = await fetch(`${base}${path}`, {
+  const activeBase = base ?? getBase()
+  const res = await fetch(`${activeBase}${path}`, {
     headers: { "Content-Type": "application/json", ...init?.headers },
     ...init,
   })


### PR DESCRIPTION
## Summary
- `request.ts` now reads `useSettingsStore.getState().backendUrl` on every call via `getBase()` — empty/sentinel falls back to `/api/portal` (demo), custom URL composes `{url}/api/portal/...`.
- `isBackendAlive()` invalidates its cache when the user swaps backends so the next probe targets the new origin.
- `BASE` export kept as a string-coercible Proxy to preserve compat with the ~7 direct `fetch(\`${BASE}/...\`)` sites in `datasets.ts` / `styles.ts` (avoids out-of-scope refactor).
- 11 new vitest cases assert URL composition across empty / custom / trailing-slash / HTTPS / live re-resolution / cache invalidation. Total 422 → 433 passing.

## Why P0
Without this, PR #40's SettingsPanel was a UI shell — user choice persisted but SPA kept hitting the proxy. Mode 2 "Connect your engine" was non-functional.

## Path scheme contract
Backend mounts portal routes under `/api/portal/...` on every host (demo, local engine, future SaaS). Only the origin swaps:

| Store state | Resolved URL |
|---|---|
| `""` (sentinel / demo) | `/api/portal/foo` (same-origin proxy) |
| `"http://localhost:8001"` | `http://localhost:8001/api/portal/foo` |
| `"https://demo.gispulse.dev"` | `https://demo.gispulse.dev/api/portal/foo` |

## Out of scope (NOT in this PR)
- Mixed-content warning UI → issue #42
- Auth headers / API tokens → Pro tier (v1.6+)
- Migrating direct `${BASE}/...` template literals to `getBase()` → not necessary, `BASE` Proxy keeps them live

## Test plan
- [x] `pnpm test` — 433/433 green (11 new cases in `request.test.ts`)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` produces `dist/` without warnings beyond the pre-existing chunk-size note
- [x] `pnpm exec eslint` clean on changed files
- [ ] CI green after push
- [ ] Manual smoke (post-merge): set `localhost:8001` in SettingsPanel, observe `/datasets` request hit `http://localhost:8001/api/portal/datasets` in DevTools Network

## Refs
- Closes #41
- Stacks on #40 (SettingsPanel + ModeBanner)
- Memory `two_package_architecture_2026_04_30`

Signed-off-by: Simon Ducournau <simon.ducournau@gmail.com>