### PR TITLE
fix(portal): handle null dataset.format in ExplorerView (production crash)

### DIFF
--- a/src/__tests__/geoDisplay.test.ts
+++ b/src/__tests__/geoDisplay.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest"
+
+import { formatBadgeClass, formatBytes, formatNumber } from "@/lib/geo-display"
+
+describe("formatBadgeClass", () => {
+  it("returns the format-specific class for a known format", () => {
+    expect(formatBadgeClass("gpkg")).toContain("emerald")
+    expect(formatBadgeClass("GeoJSON")).toContain("orange")
+  })
+
+  it("returns the muted fallback for an unknown format", () => {
+    expect(formatBadgeClass("xyz")).toBe("bg-muted text-muted-foreground")
+  })
+
+  it("returns the muted fallback when the format is missing", () => {
+    // Regression: backend can omit `format` on freshly-uploaded datasets;
+    // the explorer view used to crash with `Cannot read properties of null
+    // (reading 'toLowerCase')` (#2026-05-02 production console error).
+    expect(formatBadgeClass(null)).toBe("bg-muted text-muted-foreground")
+    expect(formatBadgeClass(undefined)).toBe("bg-muted text-muted-foreground")
+    expect(formatBadgeClass("")).toBe("bg-muted text-muted-foreground")
+  })
+})
+
+describe("formatBytes", () => {
+  it("returns 0 B for zero", () => {
+    expect(formatBytes(0)).toBe("0 B")
+  })
+
+  it("formats kilobytes and megabytes", () => {
+    expect(formatBytes(1024)).toBe("1 KB")
+    expect(formatBytes(1024 * 1024 * 2.5)).toBe("2.5 MB")
+  })
+})
+
+describe("formatNumber", () => {
+  it("compacts thousands and millions", () => {
+    expect(formatNumber(999)).toBe("999")
+    expect(formatNumber(1500)).toBe("1.5K")
+    expect(formatNumber(2_500_000)).toBe("2.5M")
+  })
+})

--- a/src/lib/geo-display.ts
+++ b/src/lib/geo-display.ts
@@ -31,6 +31,8 @@ export const FORMAT_COLORS: Record<string, string> = {
   tiff: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
 }
 
-export function formatBadgeClass(fmt: string): string {
-  return FORMAT_COLORS[fmt.toLowerCase()] ?? "bg-muted text-muted-foreground"
+export function formatBadgeClass(fmt: string | null | undefined): string {
+  const fallback = "bg-muted text-muted-foreground"
+  if (!fmt) return fallback
+  return FORMAT_COLORS[fmt.toLowerCase()] ?? fallback
 }


### PR DESCRIPTION
## Symptom
Production console error 2026-05-02:

\`\`\`
TypeError: Cannot read properties of null (reading 'toLowerCase')
  at r (geo-display-CNCDK2Ry.js:1:818)
  at ve (ExplorerView-Cn9tLZ07.js:1:3108)
[GISPulse] Workspace error (explorer): TypeError ...
\`\`\`

The entire ExplorerView crashed (white-screened the workspace) whenever the dataset list contained a row with a missing or null \`format\` field.

## Cause
\`formatBadgeClass(fmt: string)\` in \`src/lib/geo-display.ts:35\` called \`fmt.toLowerCase()\` unconditionally. Backend lists can return rows without \`format\` (registry-driven examples, freshly-uploaded datasets, legacy rows).

## Fix
- Widen type to \`string | null | undefined\`
- Short-circuit to muted fallback class when missing
- Added \`src/__tests__/geoDisplay.test.ts\` with 6 cases covering known formats, unknown format, null/undefined/empty regression

## Test plan
- [x] \`pnpm vitest run src/__tests__/geoDisplay.test.ts\` → 6/6 pass
- [ ] Deploy to GH Pages, reload \`/explorer\`, verify console clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)