### PR TITLE
feat(portal): mode toggle + mixed-content warning (#31, #42)

### DIFF
--- a/src/__tests__/MixedContentBanner.test.tsx
+++ b/src/__tests__/MixedContentBanner.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * MixedContentBanner.test — render matrix for issue #42.
+ *
+ * The banner must appear ONLY when the portal origin is HTTPS AND the
+ * configured backend URL is plain http://. All four combinations are
+ * exercised below. happy-dom lets us mutate `window.location.protocol`
+ * directly, which jsdom historically rejected.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { MixedContentBanner } from "@/components/MixedContentBanner"
+import { useSettingsStore, STORAGE_KEY } from "@/stores/settingsStore"
+
+function resetStore() {
+  useSettingsStore.setState({
+    backendUrl: "",
+    healthStatus: "idle",
+    healthLatencyMs: null,
+    healthError: null,
+    panelOpen: false,
+    readOnlyDialogOpen: false,
+  })
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* noop */
+  }
+}
+
+function setProtocol(protocol: "http:" | "https:") {
+  // happy-dom exposes window.location as a writable structure; this is
+  // safer than messing with global descriptors.
+  Object.defineProperty(window.location, "protocol", {
+    configurable: true,
+    value: protocol,
+  })
+}
+
+describe("MixedContentBanner", () => {
+  beforeEach(() => {
+    resetStore()
+    setProtocol("http:")
+  })
+  afterEach(() => {
+    cleanup()
+    setProtocol("http:")
+  })
+
+  it("renders nothing when origin is HTTP and backend is HTTP", () => {
+    setProtocol("http:")
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    render(<MixedContentBanner />)
+    expect(screen.queryByTestId("mixed-content-banner")).toBeNull()
+  })
+
+  it("renders nothing when origin is HTTPS and backend is HTTPS", () => {
+    setProtocol("https:")
+    useSettingsStore.setState({ backendUrl: "https://api.example.com" })
+    render(<MixedContentBanner />)
+    expect(screen.queryByTestId("mixed-content-banner")).toBeNull()
+  })
+
+  it("renders nothing when backend is empty (demo mode)", () => {
+    setProtocol("https:")
+    useSettingsStore.setState({ backendUrl: "" })
+    render(<MixedContentBanner />)
+    expect(screen.queryByTestId("mixed-content-banner")).toBeNull()
+  })
+
+  it("renders the warning when origin is HTTPS and backend is HTTP", () => {
+    setProtocol("https:")
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    render(<MixedContentBanner />)
+    const banner = screen.getByTestId("mixed-content-banner")
+    expect(banner).toBeTruthy()
+    expect(banner.getAttribute("role")).toBe("alert")
+    // The banner must include actionable copy (mentions gispulse portal CLI).
+    expect(banner.textContent).toMatch(/gispulse portal/i)
+  })
+
+  it("links to the portal CLI docs", () => {
+    setProtocol("https:")
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    render(<MixedContentBanner />)
+    const link = screen.getByRole("link")
+    expect(link.getAttribute("href")).toMatch(/portal/i)
+    expect(link.getAttribute("target")).toBe("_blank")
+    // External link safety
+    expect(link.getAttribute("rel")).toContain("noopener")
+  })
+})

--- a/src/__tests__/ModeToggle.test.tsx
+++ b/src/__tests__/ModeToggle.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * ModeToggle.test — segmented header control for issue #31.
+ *
+ * Validates active-segment derivation from `settingsStore.backendUrl`,
+ * the demo→engine click (opens settings), and the engine→demo click
+ * (calls reset).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+
+import { ModeToggle } from "@/components/ModeToggle"
+import { useSettingsStore, STORAGE_KEY } from "@/stores/settingsStore"
+
+function resetStore() {
+  useSettingsStore.setState({
+    backendUrl: "",
+    healthStatus: "idle",
+    healthLatencyMs: null,
+    healthError: null,
+    panelOpen: false,
+    readOnlyDialogOpen: false,
+  })
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    /* noop */
+  }
+}
+
+describe("ModeToggle", () => {
+  beforeEach(resetStore)
+  afterEach(cleanup)
+
+  it("marks the demo segment active when backendUrl is empty", () => {
+    useSettingsStore.setState({ backendUrl: "" })
+    render(<ModeToggle onOpenSettings={() => {}} />)
+    expect(screen.getByTestId("mode-toggle-demo").getAttribute("aria-pressed")).toBe("true")
+    expect(screen.getByTestId("mode-toggle-engine").getAttribute("aria-pressed")).toBe("false")
+  })
+
+  it("marks the engine segment active when backendUrl is set", () => {
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    render(<ModeToggle onOpenSettings={() => {}} />)
+    expect(screen.getByTestId("mode-toggle-demo").getAttribute("aria-pressed")).toBe("false")
+    expect(screen.getByTestId("mode-toggle-engine").getAttribute("aria-pressed")).toBe("true")
+  })
+
+  it("opens settings when demo user clicks 'My engine'", () => {
+    const onOpen = vi.fn()
+    useSettingsStore.setState({ backendUrl: "" })
+    render(<ModeToggle onOpenSettings={onOpen} />)
+    fireEvent.click(screen.getByTestId("mode-toggle-engine"))
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls reset() when engine user clicks 'Try it'", () => {
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    render(<ModeToggle onOpenSettings={() => {}} />)
+    fireEvent.click(screen.getByTestId("mode-toggle-demo"))
+    expect(useSettingsStore.getState().backendUrl).toBe("")
+  })
+
+  it("attaches the read-only tooltip on the active demo segment", () => {
+    useSettingsStore.setState({ backendUrl: "" })
+    render(<ModeToggle onOpenSettings={() => {}} />)
+    const demo = screen.getByTestId("mode-toggle-demo")
+    expect(demo.getAttribute("title")).toMatch(/read-only|lecture seule/i)
+  })
+
+  it("does NOT show tooltip on demo segment when user is on engine", () => {
+    useSettingsStore.setState({ backendUrl: "http://localhost:8001" })
+    render(<ModeToggle onOpenSettings={() => {}} />)
+    const demo = screen.getByTestId("mode-toggle-demo")
+    expect(demo.getAttribute("title")).toBeNull()
+  })
+})

--- a/src/components/MixedContentBanner.tsx
+++ b/src/components/MixedContentBanner.tsx
@@ -1,0 +1,67 @@
+/**
+ * MixedContentBanner — Issue #42.
+ *
+ * The portal can be served from a HTTPS origin (gispulse.dev GH Pages,
+ * a Pro tenant under Pro TLS, …) while the user keeps a plain `http://`
+ * backend in `settingsStore.backendUrl` (typically `http://localhost:8001`
+ * pointing at a developer's `gispulse portal`). Browsers refuse such
+ * cross-protocol requests as "active mixed content" and the failure is
+ * silent in DevTools network → users get a blank UI with no feedback.
+ *
+ * This banner detects the combination at runtime and tells the user
+ * how to recover (use `gispulse portal` for same-origin mounting, or
+ * serve their backend over HTTPS).
+ *
+ * Render conditions (all must be true):
+ *   - we are in a browser (`window` defined)
+ *   - `window.location.protocol === "https:"`
+ *   - `settingsStore.backendUrl` starts with `http://` (case-insensitive)
+ *
+ * The banner is intentionally non-dismissable: the failure mode is
+ * silent in the network panel, so a "X" close button would let users
+ * forget about a real blocker. They escape by changing the backend or
+ * the portal origin instead.
+ */
+
+import { useMemo } from "react"
+import { AlertTriangle, ExternalLink } from "lucide-react"
+import { useT } from "@/i18n/useT"
+import { useSettingsStore } from "@/stores/settingsStore"
+
+const DOCS_HREF = "https://imagodata.github.io/gispulse/cli/portal.html"
+
+export function MixedContentBanner() {
+  const t = useT()
+  const backendUrl = useSettingsStore((s) => s.backendUrl)
+
+  const shouldRender = useMemo(() => {
+    if (typeof window === "undefined") return false
+    if (window.location.protocol !== "https:") return false
+    if (!backendUrl) return false
+    return backendUrl.toLowerCase().startsWith("http://")
+  }, [backendUrl])
+
+  if (!shouldRender) return null
+
+  return (
+    <div
+      role="alert"
+      data-testid="mixed-content-banner"
+      className="flex items-start gap-2 border-b border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs text-amber-800 dark:text-amber-200 shrink-0"
+    >
+      <AlertTriangle size={14} className="mt-0.5 shrink-0" aria-hidden="true" />
+      <span className="leading-snug">
+        {t("mixed_content.banner")}{" "}
+        <a
+          href={DOCS_HREF}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-0.5 underline underline-offset-2 hover:no-underline"
+        >
+          {t("mixed_content.learn_more")}
+          <ExternalLink size={10} aria-hidden="true" />
+        </a>
+      </span>
+    </div>
+  )
+}

--- a/src/components/ModeToggle.tsx
+++ b/src/components/ModeToggle.tsx
@@ -1,0 +1,76 @@
+/**
+ * ModeToggle — Compact segmented control in the TopNav (#31).
+ *
+ * Two segments: "Try it" (= demo / built-in proxy backend) and
+ * "My engine" (= user-configured backend). Active segment is decided
+ * from `settingsStore.backendUrl`:
+ *   - empty string → "demo" segment is active
+ *   - any other value → "engine" segment is active
+ *
+ * Behaviour:
+ *   - Click "Try it" while on engine: `reset()` (returns to empty
+ *     backend, no modal — symmetric to `ModeBanner.switch_to_demo`).
+ *   - Click "My engine" while on demo: open SettingsPanel so the user
+ *     can paste their backend URL.
+ *
+ * Read-only signal: when on demo, the segment carries a tooltip
+ * (`title=mode.toggle.readonly_tooltip`) so users hovering over the
+ * "Try it" pill discover that demo write-actions are blocked.
+ *
+ * The wider `ModeBanner` (above content) remains the primary visual
+ * confirmation; this toggle is the discoverable header affordance
+ * users from QGIS/desktop expect.
+ */
+
+import { useT } from "@/i18n/useT"
+import { useSettingsStore } from "@/stores/settingsStore"
+
+interface Props {
+  onOpenSettings: () => void
+}
+
+export function ModeToggle({ onOpenSettings }: Props) {
+  const t = useT()
+  const backendUrl = useSettingsStore((s) => s.backendUrl)
+  const reset = useSettingsStore((s) => s.reset)
+
+  const isDemo = backendUrl === ""
+
+  const baseCls =
+    "px-2 py-0.5 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current rounded"
+  const activeCls = "bg-foreground text-background"
+  const idleCls = "text-muted-foreground hover:text-foreground"
+
+  return (
+    <div
+      role="group"
+      aria-label={t("mode.toggle.try_it") + " / " + t("mode.toggle.my_engine")}
+      data-testid="mode-toggle"
+      className="inline-flex items-center gap-0.5 rounded border bg-background/40 p-0.5 mr-1"
+    >
+      <button
+        type="button"
+        onClick={() => {
+          if (!isDemo) reset()
+        }}
+        aria-pressed={isDemo}
+        title={isDemo ? t("mode.toggle.readonly_tooltip") : undefined}
+        className={`${baseCls} ${isDemo ? activeCls : idleCls}`}
+        data-testid="mode-toggle-demo"
+      >
+        {t("mode.toggle.try_it")}
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          if (isDemo) onOpenSettings()
+        }}
+        aria-pressed={!isDemo}
+        className={`${baseCls} ${!isDemo ? activeCls : idleCls}`}
+        data-testid="mode-toggle-engine"
+      >
+        {t("mode.toggle.my_engine")}
+      </button>
+    </div>
+  )
+}

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -22,6 +22,7 @@ import { useLiveEventStore } from "@/hooks/useLiveEvents"
 import { useJobStore } from "@/stores/jobStore"
 import { useThemeStore } from "@/stores/themeStore"
 import { useSettingsStore } from "@/stores/settingsStore"
+import { ModeToggle } from "@/components/ModeToggle"
 import { UserMenu } from "@/components/UserMenu"
 import { useT } from "@/i18n/useT"
 // AdminGuard / isAdmin live in the private `gispulse-portal-pro` package.
@@ -108,6 +109,9 @@ export function TopNav() {
             {runningJobs} job{runningJobs > 1 ? "s" : ""}
           </div>
         )}
+
+        {/* Mode toggle — #31 (Mode 2 portal: Try it / My engine segmented) */}
+        <ModeToggle onOpenSettings={() => setSettingsOpen(true)} />
 
         {/* Theme toggle — #208 */}
         <button

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -224,6 +224,21 @@ export const STRINGS = {
   },
   "mode.readonly.cta_docs": { en: "How to connect", fr: "Comment se connecter" },
   "mode.readonly.cta_settings": { en: "Open settings", fr: "Ouvrir les paramètres" },
+
+  // ─── Mode toggle (header segmented control — issue #31) ───────────────────
+  "mode.toggle.try_it": { en: "Try it", fr: "Essayer" },
+  "mode.toggle.my_engine": { en: "My engine", fr: "Mon moteur" },
+  "mode.toggle.readonly_tooltip": {
+    en: "Read-only on demo — switch to My engine to run your own pipelines",
+    fr: "Lecture seule sur la démo — passez à Mon moteur pour exécuter vos pipelines",
+  },
+
+  // ─── Mixed-content warning banner (issue #42) ─────────────────────────────
+  "mixed_content.banner": {
+    en: "Mixed content: your browser will block requests from HTTPS to your local HTTP backend. Use `gispulse portal` to bind the SPA same-origin, or run portal over HTTPS.",
+    fr: "Contenu mixte : votre navigateur bloquera les requêtes HTTPS vers votre backend HTTP local. Utilisez `gispulse portal` pour un montage same-origin, ou accédez au portail via HTTPS.",
+  },
+  "mixed_content.learn_more": { en: "Learn more", fr: "En savoir plus" },
 } as const satisfies Record<string, Bilingual>
 
 export type StringKey = keyof typeof STRINGS

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -8,6 +8,7 @@ import { TriggerBuilderModal } from "@/components/triggers/TriggerBuilderModal"
 import { JobTrackerCorner } from "@/components/JobTrackerCorner"
 import { BackendStatusBanner } from "@/components/BackendStatusBanner"
 import { ModeBanner } from "@/components/ModeBanner"
+import { MixedContentBanner } from "@/components/MixedContentBanner"
 import { SettingsPanel } from "@/components/SettingsPanel"
 import { ReadOnlyDemoDialog } from "@/components/ReadOnlyDemoDialog"
 import { CommandPalette } from "@/components/CommandPalette"
@@ -74,6 +75,7 @@ export function RootLayout() {
   if (!activeProjectId) {
     return (
       <TooltipProvider>
+        <MixedContentBanner />
         <ModeBanner onOpenSettings={handleOpenSettings} />
         <BackendStatusBanner />
         <ProjectsPage />


### PR DESCRIPTION
## Summary
Two related Mode 2 portal pieces from milestone v1.5.1, shipped together because they share the settingsStore + RootLayout surface.

## #31 — Mode toggle in TopNav
Compact "Try it / My engine" segmented control next to the theme button. Active segment is derived from \`settingsStore.backendUrl\` (empty → demo). Click "My engine" on demo opens SettingsPanel; click "Try it" on engine calls \`reset()\`. The active demo segment exposes a tooltip warning that demo write-actions are blocked.

The existing wider ModeBanner keeps its visual confirmation role above content; the toggle is the discoverable header affordance users coming from QGIS / desktop expect.

## #42 — Mixed-content warning
New \`MixedContentBanner\` mounted at the top of RootLayout. Renders ONLY when \`window.location.protocol === "https:"\` AND \`settingsStore.backendUrl\` starts with \`http://\` (typically \`http://localhost:8001\` from a dev backend visited on the gispulse.dev GH Pages portal).

Without this banner users get a blank UI with no actionable feedback (the failure is silent in the DevTools network panel because the browser blocks the request before it leaves). Banner links to the \`gispulse portal\` CLI docs and is intentionally non-dismissable.

## i18n
Added \`mode.toggle.*\` (3 keys) and \`mixed_content.*\` (2 keys) to the existing FR/EN STRINGS dictionary.

## Tests
- \`src/__tests__/MixedContentBanner.test.tsx\` — 5 tests covering the 4-state HTTPS/HTTP × backend matrix + external-link safety attrs
- \`src/__tests__/ModeToggle.test.tsx\` — 6 tests covering active segment per backend state, click handlers, tooltip presence

All 11 pass under happy-dom; \`pnpm build\` succeeds.

Closes #31
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)