### PR TITLE
feat(palette): surface pointcloud capabilities (4 OSS + 2 Pro)

### DIFF
--- a/src/components/nodes/NodePalette.tsx
+++ b/src/components/nodes/NodePalette.tsx
@@ -61,6 +61,16 @@ const PALETTE_NODES: PaletteNode[] = [
   // Output
   { type: "output", label: "Output", description: "Export results", category: "output", icon: Download },
 
+  // Point clouds (4 OSS + 2 Pro). Pro entries carry `(Pro)` in description; the
+  // backend tier gate (persistence.tier.check_tier) raises TierError at runtime
+  // for Community licences — palette stays advertising the upgrade path.
+  { type: "capability", label: "Load LAS/LAZ", description: "Load LAS/LAZ as Point Z layer", category: "pointcloud", icon: Database, defaultData: { capability: "pointcloud_load_las", label: "Load LAS/LAZ" } },
+  { type: "capability", label: "Filter Classes", description: "Keep ASPRS class codes (e.g. 2, 6)", category: "pointcloud", icon: Cog, defaultData: { capability: "pointcloud_filter_classification", label: "Filter Classes" } },
+  { type: "capability", label: "Zonal Height", description: "Height stats per polygon zone", category: "pointcloud", icon: BarChart3, defaultData: { capability: "pointcloud_zonal_height", label: "Zonal Height" } },
+  { type: "capability", label: "Grid Summary", description: "Gridded point cloud summary", category: "pointcloud", icon: Calculator, defaultData: { capability: "pointcloud_grid_summary", label: "Grid Summary" } },
+  { type: "capability", label: "IGN Download", description: "(Pro) Download IGN LiDAR HD by bbox", category: "pointcloud", icon: Download, defaultData: { capability: "pointcloud_ign_download", label: "IGN Download" } },
+  { type: "capability", label: "Enrich", description: "(Pro) Add normals/curvature/density features", category: "pointcloud", icon: Sparkles, defaultData: { capability: "pointcloud_enrich", label: "Enrich" } },
+
   // ── Trigger Operations ──────────────────────────────────
   // Tables
   { type: "tableSource", label: "Table Source", description: "DML event source (INSERT/UPDATE/DELETE)", category: "ops_table", icon: Table2, defaultData: { nodeKind: "tableSource", label: "Table Source", schema: "", table: "", event: "INSERT" } },
@@ -110,6 +120,7 @@ const CATEGORIES: { id: NodeCategory; label: string; icon: React.ComponentType<{
   // Pipeline nodes
   { id: "source", label: "Sources", icon: Database, group: "Pipeline" },
   { id: "transform", label: "Processing", icon: Cog, group: "Pipeline" },
+  { id: "pointcloud", label: "Point Cloud", icon: Layers, group: "Pipeline" },
   { id: "control", label: "Logic", icon: GitBranch, group: "Pipeline" },
   { id: "trigger", label: "Triggers", icon: Zap, group: "Pipeline" },
   { id: "code", label: "Code", icon: Code, group: "Pipeline" },
@@ -128,6 +139,7 @@ const CAT_COLORS: Record<NodeCategory, string> = {
   ops_aggregate: "text-[var(--gp-node-output)]",
   ops_validation: "text-[var(--gp-node-control)]",
   ops_custom: "text-[var(--gp-node-code)]",
+  pointcloud: "text-[var(--gp-node-transform)]",
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/nodes/nodeStyles.ts
+++ b/src/components/nodes/nodeStyles.ts
@@ -3,7 +3,7 @@
  * All nodes use this for consistent borders, backgrounds, and text colors.
  */
 
-export type NodeCategory = "source" | "transform" | "output" | "trigger" | "control" | "code" | "ops_table" | "ops_spatial" | "ops_aggregate" | "ops_validation" | "ops_custom"
+export type NodeCategory = "source" | "transform" | "output" | "trigger" | "control" | "code" | "ops_table" | "ops_spatial" | "ops_aggregate" | "ops_validation" | "ops_custom" | "pointcloud"
 
 interface NodeStyle {
   border: string
@@ -82,6 +82,15 @@ export const NODE_STYLES: Record<NodeCategory, NodeStyle> = {
     bg: "bg-slate-50 dark:bg-slate-900/50",
     text: "text-[var(--gp-node-code)]",
     label: "Custom",
+  },
+  // Reuses --gp-node-transform (blue) — pointcloud capabilities are spatial
+  // transforms semantically (LAZ in/out + scalar fields). Avoids a new
+  // CSS variable until a dedicated 3D theme is decided.
+  pointcloud: {
+    border: "border-[var(--gp-node-transform)]",
+    bg: "bg-blue-50 dark:bg-blue-950/50",
+    text: "text-[var(--gp-node-transform)]",
+    label: "Point Cloud",
   },
 }
 


### PR DESCRIPTION
New `Point Cloud` palette section under the Pipeline group, listing 4 OSS capabilities (already in backend registry but never surfaced) + 2 Pro capabilities shipped in `gispulse-enterprise@1.7.0`.

| Label | Capability | Tier |
|---|---|---|
| Load LAS/LAZ | `pointcloud_load_las` | OSS |
| Filter Classes | `pointcloud_filter_classification` | OSS |
| Zonal Height | `pointcloud_zonal_height` | OSS |
| Grid Summary | `pointcloud_grid_summary` | OSS |
| IGN Download | `pointcloud_ign_download` | Pro |
| Enrich | `pointcloud_enrich` | Pro |

Pro entries carry a terse `(Pro)` marker in the description — the backend `persistence.tier.check_tier("pro")` raises `TierError` at runtime for Community licences, so the palette intentionally advertises the upgrade path without a blocking chip.

Style reuses `--gp-node-transform` (blue) since pointcloud capabilities are spatial transforms semantically. No new CSS variable.

## Diff scope

- `src/components/nodes/nodeStyles.ts` : +1 union member, +1 `NODE_STYLES` entry (5 lines)
- `src/components/nodes/NodePalette.tsx` : 6 palette entries + 1 category + 1 CAT_COLORS mapping (12 lines)

22 net lines, no behavioural change to existing code.

Closes #98.