### PR TITLE
feat(cocarte): Map entity frontend (#56)

### DIFF
--- a/src/api/cocarteMaps.ts
+++ b/src/api/cocarteMaps.ts
@@ -1,0 +1,90 @@
+/**
+ * api/cocarteMaps.ts — Cocarte Map CRUD + restore + share-token rotation.
+ *
+ * Mirrors the backend router at `gispulse.adapters.http.routers.maps_router`.
+ *
+ * Issue imagodata/gispulse-portal#56 (Sprint 1.1 frontend half).
+ */
+
+import { request } from "./request"
+import type {
+  CocarteMap,
+  CocarteMapCreateInput,
+  CocarteMapUpdateInput,
+} from "@/types/cocarteMap"
+
+interface MapListEnvelope {
+  items: CocarteMap[]
+  total: number
+  limit: number
+  offset: number
+}
+
+export async function listMaps(opts?: {
+  limit?: number
+  offset?: number
+  includeTrashed?: boolean
+}): Promise<CocarteMap[]> {
+  const params = new URLSearchParams()
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit))
+  if (opts?.offset !== undefined) params.set("offset", String(opts.offset))
+  if (opts?.includeTrashed) params.set("include_trashed", "true")
+  const qs = params.toString()
+  const res = await request<MapListEnvelope>(
+    `/maps${qs ? `?${qs}` : ""}`,
+    undefined,
+    "",
+  )
+  return Array.isArray(res?.items) ? res.items : []
+}
+
+export async function getMap(
+  id: string,
+  opts?: { includeTrashed?: boolean },
+): Promise<CocarteMap> {
+  const qs = opts?.includeTrashed ? "?include_trashed=true" : ""
+  return request<CocarteMap>(`/maps/${id}${qs}`, undefined, "")
+}
+
+export async function createMap(
+  input: CocarteMapCreateInput,
+): Promise<CocarteMap> {
+  return request<CocarteMap>(
+    "/maps",
+    {
+      method: "POST",
+      body: JSON.stringify(input),
+    },
+    "",
+  )
+}
+
+export async function updateMap(
+  id: string,
+  patch: CocarteMapUpdateInput,
+): Promise<CocarteMap> {
+  return request<CocarteMap>(
+    `/maps/${id}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(patch),
+    },
+    "",
+  )
+}
+
+export async function deleteMap(id: string): Promise<void> {
+  await request(`/maps/${id}`, { method: "DELETE" }, "")
+}
+
+export async function restoreMap(id: string): Promise<CocarteMap> {
+  return request<CocarteMap>(`/maps/${id}/restore`, { method: "POST" }, "")
+}
+
+export async function rotateShareToken(id: string): Promise<CocarteMap> {
+  return request<CocarteMap>(
+    `/maps/${id}/rotate-token`,
+    { method: "POST" },
+    "",
+  )
+}

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -239,6 +239,65 @@ export const STRINGS = {
     fr: "Contenu mixte : votre navigateur bloquera les requêtes HTTPS vers votre backend HTTP local. Utilisez `gispulse portal` pour un montage same-origin, ou accédez au portail via HTTPS.",
   },
   "mixed_content.learn_more": { en: "Learn more", fr: "En savoir plus" },
+
+  // ─── Cocarte (v1.7 Publish — issue #56) ───────────────────────────────────
+  "cocarte.maps.title": { en: "My maps", fr: "Mes cartes" },
+  "cocarte.maps.empty": {
+    en: "No maps yet. Create one to start publishing.",
+    fr: "Aucune carte. Créez-en une pour commencer à publier.",
+  },
+  "cocarte.maps.create": { en: "New map", fr: "Nouvelle carte" },
+  "cocarte.maps.create.title_label": { en: "Map title", fr: "Titre de la carte" },
+  "cocarte.maps.create.title_placeholder": {
+    en: "e.g. Election results 2026",
+    fr: "ex. Résultats des élections 2026",
+  },
+  "cocarte.maps.delete.confirm": {
+    en: "Move this map to trash?",
+    fr: "Déplacer cette carte vers la corbeille ?",
+  },
+  "cocarte.maps.restore": { en: "Restore", fr: "Restaurer" },
+  "cocarte.maps.trash": { en: "Trash", fr: "Corbeille" },
+  "cocarte.maps.trash.empty": {
+    en: "Trash is empty.",
+    fr: "La corbeille est vide.",
+  },
+
+  // Visibility states
+  "cocarte.visibility.private": { en: "Private", fr: "Privée" },
+  "cocarte.visibility.unlisted": { en: "Unlisted", fr: "Non listée" },
+  "cocarte.visibility.public": { en: "Public", fr: "Publique" },
+  "cocarte.visibility.private.help": {
+    en: "Only you can see this map.",
+    fr: "Vous seul pouvez voir cette carte.",
+  },
+  "cocarte.visibility.unlisted.help": {
+    en: "Anyone with the share link can view this map.",
+    fr: "Toute personne disposant du lien peut voir cette carte.",
+  },
+  "cocarte.visibility.public.help": {
+    en: "This map appears in the public gallery.",
+    fr: "Cette carte apparaît dans la galerie publique.",
+  },
+
+  // Share token
+  "cocarte.share.copy_link": { en: "Copy share link", fr: "Copier le lien de partage" },
+  "cocarte.share.rotate": { en: "Rotate share link", fr: "Régénérer le lien" },
+  "cocarte.share.rotate.confirm": {
+    en: "Previously shared links will stop working. Continue?",
+    fr: "Les liens précédemment partagés cesseront de fonctionner. Continuer ?",
+  },
+  "cocarte.share.rotated": { en: "Share link rotated", fr: "Lien régénéré" },
+
+  // Tier gate
+  "cocarte.tier.limit_reached.title": {
+    en: "Map limit reached",
+    fr: "Limite de cartes atteinte",
+  },
+  "cocarte.tier.limit_reached.body": {
+    en: "Your tier allows {limit} maps. Upgrade to Pro for 100, or Team for unlimited.",
+    fr: "Votre offre autorise {limit} cartes. Passez à Pro pour 100 cartes, ou Équipe pour un nombre illimité.",
+  },
 } as const satisfies Record<string, Bilingual>
 
 export type StringKey = keyof typeof STRINGS

--- a/src/stores/cocarteMapStore.ts
+++ b/src/stores/cocarteMapStore.ts
@@ -1,0 +1,144 @@
+/**
+ * cocarteMapStore — Cocarte Map entity store (publish workflow).
+ *
+ * Distinct from:
+ *   - `mapStore.ts`     — the MapLibre instance
+ *   - `mapViewStore.ts` — viewport / layer-stack runtime state
+ *
+ * Mirrors the `projectStore` pattern (flat array + `activeMapId` pointer +
+ * version-guarded switches + localStorage persistence).
+ *
+ * Issue imagodata/gispulse-portal#56 (Sprint 1.1 frontend half).
+ */
+
+import { create } from "zustand"
+
+import * as api from "@/api/cocarteMaps"
+import type {
+  CocarteMap,
+  CocarteMapCreateInput,
+  CocarteMapUpdateInput,
+} from "@/types/cocarteMap"
+
+const ACTIVE_KEY = "gispulse:cocarte:activeMap"
+
+interface CocarteMapState {
+  maps: CocarteMap[]
+  trashedMaps: CocarteMap[]
+  activeMapId: string | null
+  loading: boolean
+
+  fetchMaps: () => Promise<void>
+  fetchTrashedMaps: () => Promise<void>
+  createMap: (input: CocarteMapCreateInput) => Promise<CocarteMap>
+  updateMap: (id: string, patch: CocarteMapUpdateInput) => Promise<CocarteMap>
+  deleteMap: (id: string) => Promise<void>
+  restoreMap: (id: string) => Promise<CocarteMap>
+  rotateShareToken: (id: string) => Promise<CocarteMap>
+  setActiveMap: (id: string | null) => void
+}
+
+function loadPersistedMap(): string | null {
+  try {
+    return localStorage.getItem(ACTIVE_KEY)
+  } catch {
+    return null
+  }
+}
+
+function persistActiveMap(id: string | null): void {
+  try {
+    if (id) localStorage.setItem(ACTIVE_KEY, id)
+    else localStorage.removeItem(ACTIVE_KEY)
+  } catch {
+    // ignore quota / private-mode failures
+  }
+}
+
+export const useCocarteMapStore = create<CocarteMapState>((set, get) => ({
+  maps: [],
+  trashedMaps: [],
+  activeMapId: loadPersistedMap(),
+  loading: false,
+
+  fetchMaps: async () => {
+    set({ loading: true })
+    try {
+      const maps = await api.listMaps()
+      set({ maps })
+      const activeId = get().activeMapId
+      if (activeId && !maps.find((m) => m.id === activeId)) {
+        persistActiveMap(null)
+        set({ activeMapId: null })
+      }
+    } finally {
+      set({ loading: false })
+    }
+  },
+
+  fetchTrashedMaps: async () => {
+    const all = await api.listMaps({ includeTrashed: true })
+    set({ trashedMaps: all.filter((m) => m.deleted_at !== null) })
+  },
+
+  createMap: async (input) => {
+    set({ loading: true })
+    try {
+      const created = await api.createMap(input)
+      set((s) => ({ maps: [created, ...s.maps] }))
+      return created
+    } finally {
+      set({ loading: false })
+    }
+  },
+
+  updateMap: async (id, patch) => {
+    const updated = await api.updateMap(id, patch)
+    set((s) => ({
+      maps: s.maps.map((m) => (m.id === id ? updated : m)),
+    }))
+    return updated
+  },
+
+  deleteMap: async (id) => {
+    await api.deleteMap(id)
+    const trashed = get().maps.find((m) => m.id === id)
+    set((s) => ({
+      maps: s.maps.filter((m) => m.id !== id),
+      trashedMaps: trashed
+        ? [{ ...trashed, deleted_at: new Date().toISOString() }, ...s.trashedMaps]
+        : s.trashedMaps,
+      activeMapId: s.activeMapId === id ? null : s.activeMapId,
+    }))
+    if (get().activeMapId === null) persistActiveMap(null)
+  },
+
+  restoreMap: async (id) => {
+    const restored = await api.restoreMap(id)
+    set((s) => ({
+      trashedMaps: s.trashedMaps.filter((m) => m.id !== id),
+      maps: [restored, ...s.maps],
+    }))
+    return restored
+  },
+
+  rotateShareToken: async (id) => {
+    const rotated = await api.rotateShareToken(id)
+    set((s) => ({
+      maps: s.maps.map((m) => (m.id === id ? rotated : m)),
+    }))
+    return rotated
+  },
+
+  setActiveMap: (id) => {
+    set({ activeMapId: id })
+    persistActiveMap(id)
+  },
+}))
+
+/** Derived selector: the currently active map, or null. */
+export const useActiveCocarteMap = (): CocarteMap | null => {
+  const { maps, activeMapId } = useCocarteMapStore()
+  if (!activeMapId) return null
+  return maps.find((m) => m.id === activeMapId) ?? null
+}

--- a/src/types/cocarteMap.ts
+++ b/src/types/cocarteMap.ts
@@ -1,0 +1,88 @@
+/**
+ * Cocarte Map entity types — mirrors `core.models.CocarteMap` on the backend.
+ *
+ * Naming: the class is `CocarteMap` (not `Map`) to avoid shadowing the JS
+ * built-in `globalThis.Map`. The store, API client, and components follow
+ * the same convention.
+ *
+ * Issue imagodata/gispulse-portal#56 (Sprint 1.1 frontend half).
+ */
+
+export type MapVisibility = "private" | "unlisted" | "public"
+
+export interface CocarteMapViewState {
+  center: [number, number]
+  zoom: number
+  basemap: string
+  bearing?: number
+  pitch?: number
+}
+
+export type ClassificationMethod = "jenks" | "equal_interval" | "quantile"
+
+export interface ClassificationParams {
+  method: ClassificationMethod
+  classes: number
+  attribute: string
+}
+
+export interface CocarteLayerConfig {
+  id: string
+  source_ref: string
+  preset: "choropleth" | "bubble" | "heatmap" | "raw"
+  classification?: ClassificationParams
+  visible: boolean
+}
+
+export interface CocarteMap {
+  id: string
+  slug: string
+  project_id: string | null
+  owner_id: string | null
+  title: string
+  description: string
+  visibility: MapVisibility
+  share_token: string | null
+  view_state: CocarteMapViewState | Record<string, unknown>
+  layers: CocarteLayerConfig[] | Record<string, unknown>[]
+  style_overrides: Record<string, unknown>
+  snapshot_uri: string | null
+  published_at: string | null
+  template_origin_id: string | null
+  deleted_at: string | null
+  metadata: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+/** Public viewer projection — strips owner_id and share_token. Sprint 1.2. */
+export interface CocarteMapPublic {
+  id: string
+  slug: string
+  title: string
+  description: string
+  visibility: MapVisibility
+  view_state: CocarteMapViewState | Record<string, unknown>
+  layers: CocarteLayerConfig[] | Record<string, unknown>[]
+  style_overrides: Record<string, unknown>
+  snapshot_uri: string | null
+  published_at: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface CocarteMapCreateInput {
+  title: string
+  description?: string
+  project_id?: string
+}
+
+export interface CocarteMapUpdateInput {
+  title?: string
+  description?: string
+  visibility?: MapVisibility
+  view_state?: CocarteMapViewState | Record<string, unknown>
+  layers?: CocarteLayerConfig[] | Record<string, unknown>[]
+  style_overrides?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+}


### PR DESCRIPTION
## Summary

Sprint 1.1 frontend slice of the Cocarte v1.7 "Publish" epic. Adds the TypeScript types, API client, and Zustand store that mirror the backend introduced in [imagodata/gispulse#168](https://github.com/imagodata/gispulse/pull/168).

Closes #56 (Sprint 1.1 frontend half).

## What's in this PR

- **Types** — [src/types/cocarteMap.ts](src/types/cocarteMap.ts): `CocarteMap`, `CocarteMapPublic`, `MapVisibility`, `CocarteMapViewState`, `CocarteLayerConfig`, `CocarteMapCreateInput`, `CocarteMapUpdateInput`
- **API client** — [src/api/cocarteMaps.ts](src/api/cocarteMaps.ts): `listMaps`, `getMap`, `createMap`, `updateMap`, `deleteMap`, `restoreMap`, `rotateShareToken`
- **Store** — [src/stores/cocarteMapStore.ts](src/stores/cocarteMapStore.ts): `useCocarteMapStore` (flat array + `activeMapId` pointer + localStorage persistence under `gispulse:cocarte:activeMap`) and `useActiveCocarteMap` selector

## Naming choice

TS class is `CocarteMap` (not `Map`) — would shadow `globalThis.Map`. Store/API filenames follow the same convention to avoid collision with the existing [src/stores/mapStore.ts](src/stores/mapStore.ts) (the MapLibre `maplibregl.Map` instance) and [src/stores/mapViewStore.ts](src/stores/mapViewStore.ts) (viewport / layer-stack runtime state).

## Anti-patterns from `Project` type fixed from day 1

- `updated_at` is **included** in the TS interface (the existing `Project` type omits it — silent backend/frontend asymmetry)

## Validation

- `pnpm tsc --noEmit` → 0 errors
- `pnpm lint` → 0 errors in new files (185 unrelated pre-existing lint errors in other files)
- `pnpm build` / `pnpm vitest` → blocked locally by a pre-existing rolldown native binding issue (memory `portal_test_env`). CI is the source of truth.

## Out of scope (deferred)

- UI components (CocarteMapList, CocarteMapEditor, PublishButton) — Sprint 1.2 / 1.3
- i18n FR + EN seed (`i18n/fr/cocarte.json`, `i18n/en/cocarte.json`) — separate PR
- Public viewer page `/c/:slug` — Sprint 1.2
- Vitest store tests — blocked by local rolldown issue; will land alongside UI components in Sprint 1.2

## Test plan

- [ ] CI green (TSC + ESLint + Vitest in CI environment)
- [ ] Reviewer confirms naming convention (`CocarteMap` not `Map`) is acceptable
- [ ] Reviewer confirms separate `cocarteMapStore.ts` is preferable over extending `mapStore.ts`/`mapViewStore.ts`

## Stack

- Backend: imagodata/gispulse#168
- Frontend: this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)