### PR TITLE
feat(v19): portal Worldwide aggregator tab (A12, #238)

### DIFF
--- a/src/__tests__/worldwideAggregator.test.tsx
+++ b/src/__tests__/worldwideAggregator.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * worldwideAggregator.test — A12 / issue #238 (EPIC v1.9.0 #226).
+ *
+ * Covers the two acceptance criteria most easily unit-tested:
+ *  1. The jurisdiction pre-filter on the worldwide catalog store narrows
+ *     the gallery and re-fetches with the right filter.
+ *  2. The "Materialize" button stays disabled until a bbox is drawn.
+ *
+ * MapLibre is mocked so the dialog can mount in happy-dom without a
+ * real WebGL context.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+
+import { useCatalogStore } from "@/stores/catalogStore"
+import { WorldwideMaterializeDialog } from "@/components/WorldwideMaterializeDialog"
+import type { WorldwideEntry } from "@/types/catalog"
+import type { DatasetMeta } from "@/types/dataset"
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+// maplibre-gl is a heavy WebGL dependency — stub it for the dialog's BBoxDrawMap.
+vi.mock("maplibre-gl", () => ({
+  Map: class {
+    on() {}
+    remove() {}
+    addSource() {}
+    addLayer() {}
+    getSource() {}
+    getCanvas() {
+      return { style: {} }
+    }
+    isStyleLoaded() {
+      return false
+    }
+    dragPan = { enable() {}, disable() {} }
+  },
+}))
+
+// Mock the worldwide search API so the store does not hit a real backend.
+const searchWorldwideMock = vi.fn()
+vi.mock("@/api/client", async (orig) => {
+  const actual = await orig<typeof import("@/api/client")>()
+  return { ...actual, searchWorldwide: (...a: unknown[]) => searchWorldwideMock(...a) }
+})
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const ENTRY_FR: WorldwideEntry = {
+  id: "wec:fr-cadastre",
+  name: "Cadastre FR",
+  domain: "cadastre",
+  payload: "vector",
+  jurisdiction: "FR",
+  protocol: "ogc-features",
+  family: "ign",
+  endpoint: "https://example.org/fr",
+  revision_token: "tok-fr",
+  metadata: {},
+}
+
+const ENTRY_NL: WorldwideEntry = {
+  ...ENTRY_FR,
+  id: "wec:nl-buildings",
+  name: "Buildings NL",
+  domain: "buildings",
+  jurisdiction: "NL",
+  family: "pdok",
+  endpoint: "https://example.org/nl",
+  revision_token: "tok-nl",
+}
+
+const VIRTUAL: DatasetMeta = {
+  id: "virtual:worldwide/wec:fr-cadastre",
+  name: "Cadastre FR",
+  source_path: "",
+  format: "virtual",
+  crs: "EPSG:4326",
+  file_size: 0,
+  layers: [],
+  created_at: "2026-05-19T00:00:00Z",
+  source_type: "virtual",
+  virtual_source_uri: "https://example.org/fr",
+  feature_count: null,
+  virtual_bbox: null,
+  catalog_entry: ENTRY_FR.id,
+}
+
+function resetStore() {
+  useCatalogStore.setState({
+    tab: "worldwide",
+    search: "",
+    loading: false,
+    worldwide: [],
+    worldwideFilters: {},
+    virtualDatasets: {},
+  })
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("worldwide aggregator — store jurisdiction filter (#238)", () => {
+  beforeEach(() => {
+    resetStore()
+    searchWorldwideMock.mockReset()
+  })
+
+  it("setWorldwideFilters stores the jurisdiction pre-filter", () => {
+    useCatalogStore.getState().setWorldwideFilters({ jurisdiction: "FR" })
+    expect(useCatalogStore.getState().worldwideFilters.jurisdiction).toBe("FR")
+  })
+
+  it("setWorldwideFilters re-fetches with the jurisdiction when on the worldwide tab", () => {
+    searchWorldwideMock.mockResolvedValue([ENTRY_FR])
+    useCatalogStore.getState().setWorldwideFilters({ jurisdiction: "FR" })
+    expect(searchWorldwideMock).toHaveBeenCalledTimes(1)
+    const filters = searchWorldwideMock.mock.calls[0][0]
+    expect(filters.jurisdiction).toBe("FR")
+  })
+
+  it("fetchWorldwide loads entries into the store", async () => {
+    searchWorldwideMock.mockResolvedValue([ENTRY_FR, ENTRY_NL])
+    await useCatalogStore.getState().fetchWorldwide()
+    expect(useCatalogStore.getState().worldwide).toHaveLength(2)
+  })
+
+  it("upsert/removeVirtualDataset manage the virtual dataset map", () => {
+    useCatalogStore.getState().upsertVirtualDataset(VIRTUAL)
+    expect(useCatalogStore.getState().virtualDatasets[VIRTUAL.id]).toBeDefined()
+    useCatalogStore.getState().removeVirtualDataset(VIRTUAL.id)
+    expect(useCatalogStore.getState().virtualDatasets[VIRTUAL.id]).toBeUndefined()
+  })
+})
+
+describe("WorldwideMaterializeDialog — bbox gating (#238)", () => {
+  afterEach(() => cleanup())
+
+  it("disables the Materialize button until a bbox is drawn", () => {
+    render(
+      <WorldwideMaterializeDialog
+        entry={ENTRY_FR}
+        virtual={VIRTUAL}
+        onClose={() => {}}
+        onPreviewed={() => {}}
+        onMaterialized={() => {}}
+      />,
+    )
+    const btn = screen.getByTestId("worldwide-materialize-btn")
+    // No bbox set on first render → button must be disabled.
+    expect(btn).toBeDisabled()
+  })
+
+  it("shows the draw-a-bbox hint when no bbox is set", () => {
+    render(
+      <WorldwideMaterializeDialog
+        entry={ENTRY_FR}
+        virtual={VIRTUAL}
+        onClose={() => {}}
+        onPreviewed={() => {}}
+        onMaterialized={() => {}}
+      />,
+    )
+    expect(
+      screen.getByText(/bounding box|emprise/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/api/catalog.ts
+++ b/src/api/catalog.ts
@@ -14,7 +14,10 @@ import type {
   ProjectionEntry,
   FluxEntry,
   OpenDataEntry,
+  WorldwideEntry,
+  WorldwideFilters,
 } from "@/types/catalog"
+import type { DatasetMeta } from "@/types/dataset"
 
 const CATALOG = "/api/catalog"
 
@@ -151,6 +154,86 @@ export async function importFromCatalog(
   if (!res.ok) {
     const text = await res.text()
     throw new Error(`Catalog import failed (${res.status}): ${text}`)
+  }
+  return res.json() as Promise<CatalogImportResult>
+}
+
+// ---------------------------------------------------------------------------
+// Worldwide aggregator (EPIC v1.9.0 #226 — issue #238 / A12)
+//
+// Four endpoints under /api/catalog:
+//   GET  /worldwide                              — browse aggregated catalog
+//   POST /virtual                                — create a virtual dataset
+//   GET  /virtual/{id:path}/preview              — scan a bbox for stats
+//   POST /virtual/{id:path}/materialize          — download to a real dataset
+//
+// `virtual_id` contains `/` and `:` (e.g. "virtual:worldwide/<entry>"); the
+// backend declares the path param as `{virtual_id:path}` so we pass the id
+// verbatim (only encoding the bbox query string).
+// ---------------------------------------------------------------------------
+
+/** Browse the worldwide catalog with optional jurisdiction / domain filters. */
+export async function searchWorldwide(
+  filters?: WorldwideFilters,
+  signal?: AbortSignal,
+): Promise<WorldwideEntry[]> {
+  const params = new URLSearchParams()
+  if (filters?.search) params.set("search", filters.search)
+  if (filters?.domain) params.set("domain", filters.domain)
+  if (filters?.payload) params.set("payload", filters.payload)
+  if (filters?.jurisdiction) params.set("jurisdiction", filters.jurisdiction)
+  if (filters?.protocol) params.set("protocol", filters.protocol)
+  if (filters?.family) params.set("family", filters.family)
+  const qs = params.toString() ? `?${params}` : ""
+  return catalogRequest<WorldwideEntry[]>(`/worldwide${qs}`, [], signal)
+}
+
+/** Create a virtual (lazy) dataset from a worldwide catalog entry. */
+export async function createVirtualDataset(
+  entryId: string,
+  source = "worldwide",
+): Promise<DatasetMeta> {
+  const res = await fetch(`${CATALOG}/virtual`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ entry_id: entryId, source }),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Virtual dataset creation failed (${res.status}): ${text}`)
+  }
+  return res.json() as Promise<DatasetMeta>
+}
+
+/** Preview a virtual dataset — scans a bbox for feature_count / virtual_bbox. */
+export async function previewVirtualDataset(
+  virtualId: string,
+  bbox?: [number, number, number, number] | null,
+): Promise<DatasetMeta> {
+  const qs = bbox ? `?bbox=${encodeURIComponent(bbox.join(","))}` : ""
+  // virtualId is a `{id:path}` param — pass verbatim, do not encodeURIComponent.
+  const res = await fetch(`${CATALOG}/virtual/${virtualId}/preview${qs}`)
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Virtual preview failed (${res.status}): ${text}`)
+  }
+  return res.json() as Promise<DatasetMeta>
+}
+
+/** Materialise a virtual dataset to a real on-disk dataset within a bbox. */
+export async function materializeVirtualDataset(
+  virtualId: string,
+  name: string,
+  bbox: [number, number, number, number],
+): Promise<CatalogImportResult> {
+  const res = await fetch(`${CATALOG}/virtual/${virtualId}/materialize`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, bbox }),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`Materialization failed (${res.status}): ${text}`)
   }
   return res.json() as Promise<CatalogImportResult>
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -101,6 +101,10 @@ export {
   searchOpenData,
   searchCatalog,
   getCatalogEntry,
+  searchWorldwide,
+  createVirtualDataset,
+  previewVirtualDataset,
+  materializeVirtualDataset,
 } from "./catalog"
 
 // Relations (Hybrid Schema)

--- a/src/components/CatalogImportDialog.tsx
+++ b/src/components/CatalogImportDialog.tsx
@@ -38,7 +38,9 @@ type BBox = [number, number, number, number] // [west, south, east, north]
 // BBox draw map
 // ---------------------------------------------------------------------------
 
-function BBoxDrawMap({
+export type CatalogBBox = BBox
+
+export function BBoxDrawMap({
   bbox,
   onBBoxChange,
   initialCenter,

--- a/src/components/CatalogWorkspace.tsx
+++ b/src/components/CatalogWorkspace.tsx
@@ -6,18 +6,19 @@
  */
 
 import { useEffect, useState, useCallback, Suspense, lazy } from "react"
-import { Search, Star, X, Globe, Map, Layers, Compass, ChevronRight, Download, MapPin } from "lucide-react"
+import { Search, Star, X, Globe, Map, Layers, Compass, ChevronRight, Download, MapPin, Earth } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { toast } from "sonner"
-import { useCatalogStore, detectSpatialContext } from "@/stores/catalogStore"
+import { useCatalogStore, detectSpatialContext, type CatalogTab } from "@/stores/catalogStore"
 import { useCatalogFavoritesStore } from "@/stores/catalogFavoritesStore"
 import { useDatasetStore } from "@/stores/datasetStore"
 import { useUIStore } from "@/stores/uiStore"
 import { useMapViewStore, layerKey } from "@/stores/mapViewStore"
 import { useExternalLayersStore } from "@/stores/externalLayersStore"
 import { importDatasetFromUrl } from "@/api/client"
+import { createVirtualDataset, type CatalogImportResult } from "@/api/catalog"
 import { navigateToView } from "@/router"
 import {
   BasemapCard,
@@ -27,6 +28,9 @@ import {
 } from "@/components/CatalogCard"
 import { SmartSuggestions } from "@/components/SmartSuggestions"
 import { CatalogImportDialog } from "@/components/CatalogImportDialog"
+import { WorldwideEntryCard } from "@/components/WorldwideEntryCard"
+import { WorldwideMaterializeDialog } from "@/components/WorldwideMaterializeDialog"
+import { useT } from "@/i18n/useT"
 import type { CatalogDomain } from "@/types/catalog"
 import type {
   BasemapEntry,
@@ -34,7 +38,9 @@ import type {
   FluxEntry,
   OpenDataEntry,
   CatalogEntry,
+  WorldwideEntry,
 } from "@/types/catalog"
+import type { DatasetMeta } from "@/types/dataset"
 
 // Lazy import of mini-map to avoid loading MapLibre until needed
 const CatalogExtentMap = lazy(() =>
@@ -44,7 +50,7 @@ const CatalogExtentMap = lazy(() =>
 // ---------- Domain definitions ----------
 
 interface DomainDef {
-  value: CatalogDomain
+  value: CatalogTab
   label: string
   icon: typeof Map
   description: string
@@ -55,6 +61,8 @@ const DOMAINS: DomainDef[] = [
   { value: "flux", label: "Flux OGC", icon: Layers, description: "WMS, WFS, WMTS, OGC Features" },
   { value: "opendata", label: "Open Data", icon: Globe, description: "Jeux de données téléchargeables" },
   { value: "projection", label: "Projections", icon: Compass, description: "Systèmes de coordonnées" },
+  // Worldwide aggregator tab (issue #238 / A12) — global geo-data catalog.
+  { value: "worldwide", label: "Worldwide", icon: Earth, description: "Catalogue mondial" },
 ]
 
 // ---------- Protocol / provider filter helpers ----------
@@ -70,8 +78,8 @@ function getProviders(entries: CatalogEntry[]): string[] {
 // ---------- Sidebar ----------
 
 interface SidebarProps {
-  domain: CatalogDomain
-  onDomainChange: (d: CatalogDomain) => void
+  domain: CatalogTab
+  onDomainChange: (d: CatalogTab) => void
   protocolFilter: string | null
   onProtocolFilter: (p: string | null) => void
   providerFilter: string | null
@@ -82,6 +90,10 @@ interface SidebarProps {
   showFavoritesOnly: boolean
   onToggleFavorites: () => void
   totalEntries: number
+  /** Worldwide jurisdiction pre-filter (#238) — only shown on the worldwide tab. */
+  jurisdictionFilter: string | null
+  onJurisdictionFilter: (j: string | null) => void
+  availableJurisdictions: string[]
 }
 
 function Sidebar({
@@ -97,6 +109,9 @@ function Sidebar({
   showFavoritesOnly,
   onToggleFavorites,
   totalEntries,
+  jurisdictionFilter,
+  onJurisdictionFilter,
+  availableJurisdictions,
 }: SidebarProps) {
   return (
     <div className="flex flex-col h-full border-r overflow-hidden w-(--width-sidebar) shrink-0">
@@ -179,8 +194,32 @@ function Sidebar({
           </div>
         )}
 
+        {/* Jurisdiction pre-filter (Worldwide only) — issue #238 / A12 */}
+        {domain === "worldwide" && availableJurisdictions.length > 0 && (
+          <div className="px-2 py-2 border-t">
+            <p className="px-2 pt-1 pb-1 text-label font-semibold uppercase tracking-wider text-muted-foreground">
+              Jurisdiction
+            </p>
+            {availableJurisdictions.map((j) => (
+              <button
+                key={j}
+                data-testid={`worldwide-jurisdiction-${j}`}
+                onClick={() => onJurisdictionFilter(jurisdictionFilter === j ? null : j)}
+                className={`w-full flex items-center gap-2 rounded-md px-2 py-1 text-left text-xs transition-colors ${
+                  jurisdictionFilter === j
+                    ? "bg-primary/10 text-primary font-medium"
+                    : "text-foreground hover:bg-accent"
+                }`}
+              >
+                <span className="font-mono uppercase text-label">{j}</span>
+                {jurisdictionFilter === j && <X size={10} className="ml-auto" />}
+              </button>
+            ))}
+          </div>
+        )}
+
         {/* Provider filter */}
-        {availableProviders.length > 0 && (
+        {domain !== "worldwide" && availableProviders.length > 0 && (
           <div className="px-2 py-2 border-t">
             <p className="px-2 pt-1 pb-1 text-label font-semibold uppercase tracking-wider text-muted-foreground">
               Provider
@@ -621,9 +660,12 @@ export function CatalogWorkspace() {
   const {
     tab, search, loading,
     projections, basemaps, flux, opendata,
+    worldwide, worldwideFilters, virtualDatasets,
     spatialContext,
     setTab, setSearch, fetchTab, fetchProviders, setSpatialContext,
+    setWorldwideFilters, upsertVirtualDataset,
   } = useCatalogStore()
+  const t = useT()
 
   const datasets = useDatasetStore((s) => s.datasets)
   const addDataset = useDatasetStore((s) => s.addDataset)
@@ -642,6 +684,15 @@ export function CatalogWorkspace() {
   const [imported, setImported] = useState<Set<string>>(new Set())
   const [importDialogEntry, setImportDialogEntry] = useState<AnyEntry | null>(null)
 
+  // ─── Worldwide aggregator state (#238 / A12) ──────────────────────────────
+  const [selectedWorldwideId, setSelectedWorldwideId] = useState<string | null>(null)
+  const [worldwideBusy, setWorldwideBusy] = useState<string | null>(null)
+  /** entry.id of worldwide entries that have been materialized this session. */
+  const [materializedEntries, setMaterializedEntries] = useState<Set<string>>(new Set())
+  /** Worldwide entry currently open in the materialize dialog. */
+  const [materializeEntry, setMaterializeEntry] = useState<WorldwideEntry | null>(null)
+  const jurisdictionFilter = worldwideFilters.jurisdiction ?? null
+
   // Sync spatial context
   useEffect(() => {
     const ctx = detectSpatialContext(datasets)
@@ -655,23 +706,36 @@ export function CatalogWorkspace() {
   }, [])
 
   // Reset filters when domain changes
-  const handleDomainChange = useCallback((d: CatalogDomain) => {
+  const handleDomainChange = useCallback((d: CatalogTab) => {
     setTab(d)
     setProtocolFilter(null)
     setProviderFilter(null)
     setSelectedEntry(null)
+    setSelectedWorldwideId(null)
     setShowFavoritesOnly(false)
   }, [setTab])
 
-  // Get current domain entries
+  // Get current domain entries (worldwide handled by its own grid)
   const rawEntries: AnyEntry[] = (() => {
     switch (tab) {
       case "basemap": return basemaps
       case "flux": return flux
       case "opendata": return opendata
       case "projection": return projections
+      case "worldwide": return []
     }
   })()
+
+  // Apply jurisdiction pre-filter client-side as a safety net; the store
+  // already passes `jurisdiction` to the backend, but this keeps the gallery
+  // consistent if the server returns a broader set.
+  const filteredWorldwide = jurisdictionFilter
+    ? worldwide.filter((e) => e.jurisdiction === jurisdictionFilter)
+    : worldwide
+
+  const availableJurisdictions = Array.from(
+    new Set(worldwide.map((e) => e.jurisdiction)),
+  ).sort()
 
   // Apply favorites filter
   const favSet = new Set(favorites.map((f) => f.id))
@@ -759,7 +823,91 @@ export function CatalogWorkspace() {
     navigateToView("map")
   }, [addFluxLayer, hasLayer])
 
-  const totalEntries = basemaps.length + flux.length + opendata.length + projections.length
+  // ─── Worldwide aggregator handlers (#238 / A12) ──────────────────────────
+
+  // Look up the virtual dataset created from a worldwide entry, if any.
+  const virtualForEntry = useCallback(
+    (entry: WorldwideEntry) =>
+      Object.values(virtualDatasets).find(
+        (ds) => ds.catalog_entry === entry.id,
+      ) ?? null,
+    [virtualDatasets],
+  )
+
+  const handleJurisdictionFilter = useCallback(
+    (j: string | null) => {
+      setWorldwideFilters({ ...worldwideFilters, jurisdiction: j ?? undefined })
+    },
+    [setWorldwideFilters, worldwideFilters],
+  )
+
+  // Create a virtual (lazy) dataset from a worldwide catalog entry.
+  const handleCreateVirtual = useCallback(
+    async (entry: WorldwideEntry) => {
+      setWorldwideBusy(entry.id)
+      try {
+        const ds = await createVirtualDataset(entry.id)
+        // Stamp the originating entry so the card can pair virtual ↔ entry.
+        const stamped = { ...ds, catalog_entry: ds.catalog_entry ?? entry.id }
+        upsertVirtualDataset(stamped)
+        addDataset(stamped)
+        toast.success(t("worldwide.virtual.created"))
+      } catch (err) {
+        toast.error(
+          "Virtual dataset failed: " +
+            (err instanceof Error ? err.message : String(err)),
+        )
+      } finally {
+        setWorldwideBusy(null)
+      }
+    },
+    [addDataset, upsertVirtualDataset, t],
+  )
+
+  // Open the materialize dialog for a worldwide entry's virtual dataset.
+  const handleOpenMaterialize = useCallback((entry: WorldwideEntry) => {
+    setMaterializeEntry(entry)
+  }, [])
+
+  // Preview updated stats (feature_count / virtual_bbox) — keep store in sync.
+  const handleWorldwidePreviewed = useCallback(
+    (ds: DatasetMeta) => {
+      upsertVirtualDataset(ds)
+    },
+    [upsertVirtualDataset],
+  )
+
+  // Materialization succeeded — the dataset flips from `virtual` to `project`.
+  const handleWorldwideMaterialized = useCallback(
+    (result: CatalogImportResult) => {
+      const ds: DatasetMeta = {
+        id: result.id,
+        name: result.name,
+        source_path: result.source_path ?? "",
+        format: result.format ?? "gpkg",
+        crs: result.crs ?? "EPSG:4326",
+        file_size: result.file_size ?? 0,
+        layers: (result.layers as DatasetMeta["layers"]) ?? [],
+        created_at: result.created_at ?? new Date().toISOString(),
+        source_type: "project",
+        catalog_entry: result.catalog_entry,
+      }
+      addDataset(ds)
+      for (const l of ds.layers) {
+        const ln = (l as { name?: string }).name
+        if (ln) addLayer(layerKey(ds.id, ln))
+      }
+      if (materializeEntry) {
+        // Flip the badge: virtual → project.
+        setMaterializedEntries((s) => new Set(s).add(materializeEntry.id))
+      }
+      setMaterializeEntry(null)
+      toast.success(t("worldwide.virtual.materialized"))
+    },
+    [addDataset, addLayer, materializeEntry, t],
+  )
+
+  const totalEntries = basemaps.length + flux.length + opendata.length + projections.length + worldwide.length
 
   // Memoized callbacks to avoid re-rendering child components on each render (#199)
   const handleToggleFavorites = useCallback(() => setShowFavoritesOnly((v) => !v), [])
@@ -789,6 +937,9 @@ export function CatalogWorkspace() {
         showFavoritesOnly={showFavoritesOnly}
         onToggleFavorites={handleToggleFavorites}
         totalEntries={totalEntries}
+        jurisdictionFilter={jurisdictionFilter}
+        onJurisdictionFilter={handleJurisdictionFilter}
+        availableJurisdictions={availableJurisdictions}
       />
 
       {/* Center: search + grid */}
@@ -846,10 +997,10 @@ export function CatalogWorkspace() {
         )}
 
         {/* Grid */}
-        {!loading && (
+        {!loading && tab !== "worldwide" && (
           <ScrollArea className="flex-1">
             <CatalogGrid
-              domain={tab}
+              domain={tab as CatalogDomain}
               entries={filteredEntries}
               selectedId={selectedEntry?.id ?? null}
               onSelect={handleSelectEntry}
@@ -863,19 +1014,57 @@ export function CatalogWorkspace() {
             />
           </ScrollArea>
         )}
+
+        {/* Worldwide aggregator gallery (#238 / A12) */}
+        {!loading && tab === "worldwide" && (
+          <ScrollArea className="flex-1">
+            {filteredWorldwide.length === 0 ? (
+              <div className="flex flex-col items-center justify-center flex-1 text-center py-16">
+                <Earth size={24} className="text-muted-foreground/30 mb-2" />
+                <p className="text-sm text-muted-foreground">{t("worldwide.empty")}</p>
+              </div>
+            ) : (
+              <div
+                className="grid grid-cols-1 gap-2 p-4 sm:grid-cols-2 xl:grid-cols-3"
+                data-testid="worldwide-gallery"
+              >
+                {filteredWorldwide.map((entry) => {
+                  const virtual = virtualForEntry(entry)
+                  return (
+                    <WorldwideEntryCard
+                      key={entry.id}
+                      entry={entry}
+                      selected={selectedWorldwideId === entry.id}
+                      onSelect={() =>
+                        setSelectedWorldwideId((p) => (p === entry.id ? null : entry.id))
+                      }
+                      virtual={virtual}
+                      materialized={materializedEntries.has(entry.id)}
+                      busy={worldwideBusy === entry.id}
+                      onCreateVirtual={() => handleCreateVirtual(entry)}
+                      onMaterialize={() => handleOpenMaterialize(entry)}
+                    />
+                  )
+                })}
+              </div>
+            )}
+          </ScrollArea>
+        )}
       </div>
 
-      {/* Right inspector */}
-      <Inspector
-        entry={selectedEntry}
-        domain={tab}
-        epsgCodes={spatialContext.epsgCodes}
-        onClose={handleCloseInspector}
-        onImport={handleImport}
-        onImportAdvanced={handleOpenImportDialog}
-        importing={importing === selectedEntry?.id}
-        imported={selectedEntry ? imported.has(selectedEntry.id) : false}
-      />
+      {/* Right inspector — domain catalogs only (worldwide uses the gallery) */}
+      {tab !== "worldwide" && (
+        <Inspector
+          entry={selectedEntry}
+          domain={tab as CatalogDomain}
+          epsgCodes={spatialContext.epsgCodes}
+          onClose={handleCloseInspector}
+          onImport={handleImport}
+          onImportAdvanced={handleOpenImportDialog}
+          importing={importing === selectedEntry?.id}
+          imported={selectedEntry ? imported.has(selectedEntry.id) : false}
+        />
+      )}
 
       {/* Import dialog with bbox selection */}
       {importDialogEntry && (
@@ -885,6 +1074,22 @@ export function CatalogWorkspace() {
           onImported={handleImportDialogResult}
         />
       )}
+
+      {/* Worldwide materialize dialog (#238 / A12) */}
+      {materializeEntry && (() => {
+        const virtual = virtualForEntry(materializeEntry)
+        if (!virtual) return null
+        return (
+          <WorldwideMaterializeDialog
+            key={materializeEntry.id}
+            entry={materializeEntry}
+            virtual={virtual}
+            onClose={() => setMaterializeEntry(null)}
+            onPreviewed={handleWorldwidePreviewed}
+            onMaterialized={handleWorldwideMaterialized}
+          />
+        )
+      })()}
     </div>
   )
 }

--- a/src/components/WorldwideEntryCard.tsx
+++ b/src/components/WorldwideEntryCard.tsx
@@ -1,0 +1,133 @@
+/**
+ * WorldwideEntryCard — gallery card for a worldwide aggregator catalog entry.
+ * Issue #238 (A12) — EPIC v1.9.0 #226 (global geo-data aggregator).
+ *
+ * Each card surfaces one `WorldwideEntry` and its lifecycle:
+ *  - not yet added            → "Add as virtual dataset"
+ *  - added (virtual)          → `virtual` badge + "Materialize" action
+ *  - materialized (project)   → `project` badge
+ *
+ * The "Materialize" button stays disabled until a bbox is drawn — the
+ * worldwide sources are global, so a bbox is mandatory (acceptance criterion).
+ */
+
+import { Globe, Plus, Box, CheckCircle2, Layers } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { useT } from "@/i18n/useT"
+import type { WorldwideEntry } from "@/types/catalog"
+import type { DatasetMeta } from "@/types/dataset"
+
+export interface WorldwideEntryCardProps {
+  entry: WorldwideEntry
+  selected: boolean
+  onSelect: () => void
+  /** The virtual dataset created from this entry, if any. */
+  virtual: DatasetMeta | null
+  /** True once the virtual dataset has been materialized to disk. */
+  materialized: boolean
+  busy: boolean
+  onCreateVirtual: () => void
+  onMaterialize: () => void
+}
+
+export function WorldwideEntryCard({
+  entry,
+  selected,
+  onSelect,
+  virtual,
+  materialized,
+  busy,
+  onCreateVirtual,
+  onMaterialize,
+}: WorldwideEntryCardProps) {
+  const t = useT()
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      data-testid={`worldwide-card-${entry.id}`}
+      className={`flex flex-col gap-1.5 rounded-md border bg-card p-2.5 text-left transition-colors ${
+        selected ? "border-primary ring-1 ring-primary/30" : "hover:bg-accent/40"
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-1.5">
+        <Globe size={14} className="shrink-0 text-muted-foreground" />
+        <span className="flex-1 min-w-0 truncate text-xs font-medium">{entry.name}</span>
+        {materialized ? (
+          <Badge
+            data-testid="worldwide-badge-project"
+            className="text-label-xs h-3.5 px-1 shrink-0 bg-emerald-500/10 text-emerald-600 border-emerald-500/20"
+          >
+            {t("worldwide.badge.project")}
+          </Badge>
+        ) : virtual ? (
+          <Badge
+            data-testid="worldwide-badge-virtual"
+            className="text-label-xs h-3.5 px-1 shrink-0 bg-violet-500/10 text-violet-600 border-violet-500/20"
+          >
+            {t("worldwide.badge.virtual")}
+          </Badge>
+        ) : null}
+      </div>
+
+      {/* Metadata row */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-label text-muted-foreground">
+        <Badge variant="outline" className="text-label-xs h-3.5 px-1 uppercase">
+          {entry.jurisdiction}
+        </Badge>
+        <span>{entry.domain}</span>
+        <span className="font-mono text-label-sm">{entry.payload}</span>
+        <span className="font-mono text-label-sm uppercase">{entry.protocol}</span>
+      </div>
+
+      {/* Feature count (after preview) */}
+      {virtual && virtual.feature_count != null && (
+        <p className="text-label-sm text-muted-foreground/70">
+          {virtual.feature_count.toLocaleString()} {t("worldwide.feature_count")}
+        </p>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-1 pt-0.5">
+        {!virtual ? (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-6 flex-1 gap-1 text-label-lg"
+            disabled={busy}
+            onClick={(e) => {
+              e.stopPropagation()
+              onCreateVirtual()
+            }}
+          >
+            <Plus size={11} />
+            {t("worldwide.action.create_virtual")}
+          </Button>
+        ) : materialized ? (
+          <span className="flex flex-1 items-center justify-center gap-1 text-label-lg text-emerald-600">
+            <CheckCircle2 size={12} />
+            {t("worldwide.virtual.materialized")}
+          </span>
+        ) : (
+          <Button
+            size="sm"
+            variant="default"
+            className="h-6 flex-1 gap-1 text-label-lg"
+            disabled={busy}
+            onClick={(e) => {
+              e.stopPropagation()
+              onMaterialize()
+            }}
+          >
+            <Box size={11} />
+            {t("worldwide.action.materialize")}
+          </Button>
+        )}
+        <Layers size={11} className="shrink-0 text-muted-foreground/30" />
+      </div>
+    </button>
+  )
+}

--- a/src/components/WorldwideMaterializeDialog.tsx
+++ b/src/components/WorldwideMaterializeDialog.tsx
@@ -1,0 +1,227 @@
+/**
+ * WorldwideMaterializeDialog — modal to materialize a virtual worldwide
+ * dataset into a real on-disk dataset.
+ * Issue #238 (A12) — EPIC v1.9.0 #226 (global geo-data aggregator).
+ *
+ * The user draws a bounding box; the "Materialize" button stays disabled
+ * until a bbox is set (acceptance criterion). An optional "Preview" call
+ * scans the remote source and reports a feature count before download.
+ */
+
+import { useCallback, useState } from "react"
+import "maplibre-gl/dist/maplibre-gl.css"
+import { Box, X, Loader2, Eye } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { BBoxDrawMap } from "@/components/CatalogImportDialog"
+import { useT } from "@/i18n/useT"
+import {
+  previewVirtualDataset,
+  materializeVirtualDataset,
+  type CatalogImportResult,
+} from "@/api/catalog"
+import type { WorldwideEntry } from "@/types/catalog"
+import type { DatasetMeta } from "@/types/dataset"
+
+type BBox = [number, number, number, number]
+
+export interface WorldwideMaterializeDialogProps {
+  entry: WorldwideEntry
+  /** The virtual dataset created from `entry`. */
+  virtual: DatasetMeta
+  onClose: () => void
+  /** Called when the preview returns updated stats (feature_count, bbox). */
+  onPreviewed: (ds: DatasetMeta) => void
+  /** Called when materialization succeeds with the real dataset. */
+  onMaterialized: (result: CatalogImportResult) => void
+}
+
+export function WorldwideMaterializeDialog({
+  entry,
+  virtual,
+  onClose,
+  onPreviewed,
+  onMaterialized,
+}: WorldwideMaterializeDialogProps) {
+  const t = useT()
+  const [bbox, setBBox] = useState<BBox | null>(null)
+  const [name, setName] = useState(entry.name)
+  const [previewing, setPreviewing] = useState(false)
+  const [materializing, setMaterializing] = useState(false)
+  const [featureCount, setFeatureCount] = useState<number | null>(
+    virtual.feature_count ?? null,
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  // No reset effect: the parent passes a `key` keyed on the entry id, so a
+  // new entry remounts the dialog fresh (avoids setState-in-effect).
+
+  const handlePreview = useCallback(async () => {
+    setPreviewing(true)
+    setError(null)
+    try {
+      const ds = await previewVirtualDataset(virtual.id, bbox)
+      setFeatureCount(ds.feature_count ?? null)
+      onPreviewed(ds)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setPreviewing(false)
+    }
+  }, [virtual.id, bbox, onPreviewed])
+
+  const handleMaterialize = useCallback(async () => {
+    if (!bbox) return
+    setMaterializing(true)
+    setError(null)
+    try {
+      const result = await materializeVirtualDataset(
+        virtual.id,
+        name.trim() || entry.name,
+        bbox,
+      )
+      onMaterialized(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setMaterializing(false)
+    }
+  }, [virtual.id, name, entry.name, bbox, onMaterialized])
+
+  const busy = previewing || materializing
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Materialize ${entry.name}`}
+        className="relative z-10 w-full max-w-lg rounded-lg border bg-background shadow-xl flex flex-col max-h-[90vh] overflow-hidden"
+      >
+        {/* Header */}
+        <div className="flex items-center gap-2 px-5 py-3 border-b">
+          <Box size={16} className="text-primary shrink-0" />
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold truncate">
+              {t("worldwide.action.materialize")}: {entry.name}
+            </h2>
+            <p className="text-label text-muted-foreground truncate">
+              {entry.jurisdiction} / {entry.domain} / {entry.family}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded p-1 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label={t("common.close")}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-4 overflow-y-auto">
+          <div>
+            <label className="text-xs font-medium text-foreground mb-1.5 block">
+              {t("worldwide.action.preview")}
+            </label>
+            <BBoxDrawMap bbox={bbox} onBBoxChange={setBBox} />
+            {bbox ? (
+              <div className="flex items-center justify-between mt-1.5">
+                <span className="text-label-sm font-mono text-muted-foreground">
+                  {bbox.map((v) => v.toFixed(4)).join(", ")}
+                </span>
+                <button
+                  onClick={() => setBBox(null)}
+                  className="text-label text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t("common.delete")}
+                </button>
+              </div>
+            ) : (
+              <p className="text-label text-amber-600 dark:text-amber-400 mt-1">
+                {t("worldwide.hint.need_bbox")}
+              </p>
+            )}
+          </div>
+
+          {/* Name */}
+          <div>
+            <label
+              htmlFor="materialize-name"
+              className="text-xs font-medium text-foreground mb-1 block"
+            >
+              {t("worldwide.action.materialize")}
+            </label>
+            <input
+              id="materialize-name"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={entry.name}
+              className="w-full rounded border border-input bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </div>
+
+          {/* Feature count after preview */}
+          {featureCount != null && (
+            <Badge variant="secondary" className="text-label">
+              {featureCount.toLocaleString()} {t("worldwide.feature_count")}
+            </Badge>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2">
+              <p className="text-xs text-destructive">{error}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t bg-muted/30">
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={busy}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handlePreview}
+            disabled={busy}
+            className="gap-1.5"
+          >
+            {previewing ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Eye size={14} />
+            )}
+            {t("worldwide.action.preview")}
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleMaterialize}
+            disabled={busy || !bbox}
+            data-testid="worldwide-materialize-btn"
+            className="gap-1.5"
+          >
+            {materializing ? (
+              <>
+                <Loader2 size={14} className="animate-spin" />
+                {t("worldwide.action.materializing")}
+              </>
+            ) : (
+              <>
+                <Box size={14} />
+                {t("worldwide.action.materialize")}
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/panels/DatasetSection.tsx
+++ b/src/components/panels/DatasetSection.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react"
-import { Pencil, Download, Trash2, Database, FileType, Link, CheckCircle2, AlertCircle } from "lucide-react"
+import { Pencil, Download, Trash2, Database, FileType, Link, CheckCircle2, AlertCircle, Globe } from "lucide-react"
 import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -161,12 +161,20 @@ export function DatasetsSection() {
   }, [])
 
   const sessionDatasets = useMemo(() => datasets.filter((ds) => ds.source_type === "session"), [datasets])
-  const projectDatasets = useMemo(() => datasets.filter((ds) => !ds.source_type || ds.source_type === "project"), [datasets])
+  // Project list also carries virtual datasets (#238 / A12) — they render
+  // with a distinct `virtual` badge until the user materializes them.
+  const projectDatasets = useMemo(
+    () => datasets.filter((ds) => !ds.source_type || ds.source_type === "project" || ds.source_type === "virtual"),
+    [datasets],
+  )
 
   const renderDataset = (ds: typeof datasets[0]) => {
     const totalFeatures = (ds.layers ?? []).reduce((a, l) => a + l.feature_count, 0)
     const isEditing = editingId === ds.id
     const isSession = ds.source_type === "session"
+    // Virtual datasets come from the worldwide aggregator (#238 / A12):
+    // lazy, not materialized to disk until the user picks a bbox.
+    const isVirtual = ds.source_type === "virtual"
 
     return (
       <div
@@ -177,7 +185,9 @@ export function DatasetsSection() {
         <div className="flex items-center gap-1.5">
           {isSession
             ? <Database size={13} className="shrink-0 text-orange-500" />
-            : <FileType size={13} className="shrink-0 text-primary/70" />
+            : isVirtual
+              ? <Globe size={13} className="shrink-0 text-violet-500" />
+              : <FileType size={13} className="shrink-0 text-primary/70" />
           }
           {isEditing ? (
             <input
@@ -196,6 +206,13 @@ export function DatasetsSection() {
           )}
           {isSession ? (
             <Badge className="text-label-xs h-3.5 px-1 shrink-0 bg-amber-500/10 text-amber-600 border-amber-500/20">PG</Badge>
+          ) : isVirtual ? (
+            <Badge
+              data-testid="dataset-badge-virtual"
+              className="text-label-xs h-3.5 px-1 shrink-0 bg-violet-500/10 text-violet-600 border-violet-500/20"
+            >
+              virtual
+            </Badge>
           ) : (
             <Badge variant="outline" className="text-label-xs h-3.5 px-1 shrink-0 uppercase">{ds.format}</Badge>
           )}

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -239,6 +239,45 @@ export const STRINGS = {
     fr: "Contenu mixte : votre navigateur bloquera les requêtes HTTPS vers votre backend HTTP local. Utilisez `gispulse portal` pour un montage same-origin, ou accédez au portail via HTTPS.",
   },
   "mixed_content.learn_more": { en: "Learn more", fr: "En savoir plus" },
+
+  // ─── Worldwide aggregator tab (EPIC v1.9.0 #226 — issue #238 / A12) ───────
+  "worldwide.tab": { en: "Worldwide", fr: "Mondial" },
+  "worldwide.tab.description": {
+    en: "Global geo-data catalog",
+    fr: "Catalogue de données géo mondiales",
+  },
+  "worldwide.filter.jurisdiction": { en: "Jurisdiction", fr: "Juridiction" },
+  "worldwide.filter.domain": { en: "Domain", fr: "Domaine" },
+  "worldwide.filter.all": { en: "All", fr: "Toutes" },
+  "worldwide.badge.virtual": { en: "virtual", fr: "virtuel" },
+  "worldwide.badge.project": { en: "project", fr: "projet" },
+  "worldwide.action.create_virtual": {
+    en: "Add as virtual dataset",
+    fr: "Ajouter en jeu virtuel",
+  },
+  "worldwide.action.preview": { en: "Preview bbox", fr: "Prévisualiser la bbox" },
+  "worldwide.action.materialize": { en: "Materialize", fr: "Matérialiser" },
+  "worldwide.action.materializing": {
+    en: "Materializing…",
+    fr: "Matérialisation…",
+  },
+  "worldwide.hint.need_bbox": {
+    en: "Draw a bounding box to enable materialization",
+    fr: "Tracez une emprise pour activer la matérialisation",
+  },
+  "worldwide.empty": {
+    en: "No worldwide entries match your filters",
+    fr: "Aucune entrée mondiale ne correspond à vos filtres",
+  },
+  "worldwide.virtual.created": {
+    en: "Virtual dataset created",
+    fr: "Jeu virtuel créé",
+  },
+  "worldwide.virtual.materialized": {
+    en: "Dataset materialized",
+    fr: "Jeu de données matérialisé",
+  },
+  "worldwide.feature_count": { en: "features", fr: "entités" },
 } as const satisfies Record<string, Bilingual>
 
 export type StringKey = keyof typeof STRINGS

--- a/src/stores/catalogStore.ts
+++ b/src/stores/catalogStore.ts
@@ -12,16 +12,24 @@ import type {
   FluxEntry,
   OpenDataEntry,
   CatalogProviderInfo,
+  WorldwideEntry,
+  WorldwideFilters,
 } from "@/types/catalog"
+import type { DatasetMeta } from "@/types/dataset"
 import {
   searchProjections,
   searchBasemaps,
   searchFlux,
   searchOpenData,
   listCatalogProviders,
+  searchWorldwide,
 } from "@/api/client"
 
-type CatalogTab = CatalogDomain
+/**
+ * Catalog tabs. "worldwide" (issue #238 / A12) is an extra tab beyond the
+ * four canonical catalog domains — it browses the global aggregated catalog.
+ */
+export type CatalogTab = CatalogDomain | "worldwide"
 
 /** Detected spatial context from loaded datasets */
 export interface SpatialContext {
@@ -40,6 +48,13 @@ interface CatalogState {
   opendata: OpenDataEntry[]
   providers: CatalogProviderInfo[]
 
+  // Worldwide aggregator (#238 / A12)
+  worldwide: WorldwideEntry[]
+  /** Pre-filter applied to the worldwide tab (jurisdiction, domain, …). */
+  worldwideFilters: WorldwideFilters
+  /** Virtual datasets created from worldwide entries, keyed by virtual id. */
+  virtualDatasets: Record<string, DatasetMeta>
+
   // Smart context
   spatialContext: SpatialContext
 
@@ -48,6 +63,12 @@ interface CatalogState {
   fetchTab: (tab?: CatalogTab, search?: string) => Promise<void>
   fetchProviders: () => Promise<void>
   setSpatialContext: (ctx: SpatialContext) => void
+
+  // Worldwide actions (#238 / A12)
+  setWorldwideFilters: (filters: WorldwideFilters) => void
+  fetchWorldwide: (search?: string) => Promise<void>
+  upsertVirtualDataset: (ds: DatasetMeta) => void
+  removeVirtualDataset: (virtualId: string) => void
 }
 
 /** Infer a country hint from a WGS84 bounding box */
@@ -128,6 +149,9 @@ export const useCatalogStore = create<CatalogState>((set, get) => ({
   flux: [],
   opendata: [],
   providers: [],
+  worldwide: [],
+  worldwideFilters: {},
+  virtualDatasets: {},
   spatialContext: { epsgCodes: [], bbox: null, country: null },
 
   setTab: (tab) => {
@@ -168,6 +192,14 @@ export const useCatalogStore = create<CatalogState>((set, get) => ({
         case "opendata":
           set({ opendata: await searchOpenData(q || undefined, signal) })
           break
+        case "worldwide": {
+          const filters: WorldwideFilters = {
+            ...get().worldwideFilters,
+            search: q || undefined,
+          }
+          set({ worldwide: await searchWorldwide(filters, signal) })
+          break
+        }
       }
     } catch (err) {
       // AbortError is expected when a newer fetch supersedes this one — silence it
@@ -188,4 +220,47 @@ export const useCatalogStore = create<CatalogState>((set, get) => ({
   },
 
   setSpatialContext: (ctx) => set({ spatialContext: ctx }),
+
+  // ─── Worldwide aggregator (#238 / A12) ──────────────────────────────────
+
+  setWorldwideFilters: (filters) => {
+    set({ worldwideFilters: filters })
+    // Re-fetch immediately so the gallery reflects the new pre-filter.
+    if (get().tab === "worldwide") {
+      get().fetchWorldwide(get().search)
+    }
+  },
+
+  fetchWorldwide: async (search) => {
+    const q = search ?? get().search
+
+    // Cancel any in-flight fetch before launching a new one (#207)
+    _fetchAbortController?.abort()
+    _fetchAbortController = new AbortController()
+    const { signal } = _fetchAbortController
+
+    set({ loading: true })
+    try {
+      const filters: WorldwideFilters = {
+        ...get().worldwideFilters,
+        search: q || undefined,
+      }
+      set({ worldwide: await searchWorldwide(filters, signal) })
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return
+      console.error("Worldwide catalog fetch failed:", err)
+    } finally {
+      if (!signal.aborted) set({ loading: false })
+    }
+  },
+
+  upsertVirtualDataset: (ds) =>
+    set((s) => ({ virtualDatasets: { ...s.virtualDatasets, [ds.id]: ds } })),
+
+  removeVirtualDataset: (virtualId) =>
+    set((s) => {
+      const next = { ...s.virtualDatasets }
+      delete next[virtualId]
+      return { virtualDatasets: next }
+    }),
 }))

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -49,3 +49,40 @@ export interface CatalogProviderInfo {
   description: string
   entry_count: number
 }
+
+// ---------------------------------------------------------------------------
+// Worldwide aggregator (EPIC v1.9.0 #226 — issue #238 / A12)
+//
+// The worldwide catalog exposes geo-data sources from many jurisdictions
+// (FR, NL, US, world, …) that can be consumed lazily as *virtual* datasets
+// — no download until the user materialises a bounding box.
+// ---------------------------------------------------------------------------
+
+/** A single entry of the worldwide aggregated catalog. */
+export interface WorldwideEntry {
+  id: string
+  name: string
+  /** Thematic domain, e.g. "cadastre", "buildings", "transport". */
+  domain: string
+  /** Payload kind, e.g. "vector", "raster", "pointcloud". */
+  payload: string
+  /** ISO jurisdiction code or "world", e.g. "FR", "NL", "US". */
+  jurisdiction: string
+  /** Access protocol, e.g. "ogc-features", "wfs", "stac". */
+  protocol: string
+  /** Fetcher family, e.g. "overture", "ign", "pdok". */
+  family: string
+  endpoint: string
+  revision_token: string
+  metadata: Record<string, unknown>
+}
+
+/** Filters accepted by GET /api/catalog/worldwide (all optional). */
+export interface WorldwideFilters {
+  search?: string
+  domain?: string
+  payload?: string
+  jurisdiction?: string
+  protocol?: string
+  family?: string
+}

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -36,8 +36,27 @@ export interface DatasetMeta {
   /** Full advanced style definitions keyed by layer name (from QGIS QML parsing). */
   style_defs?: Record<string, Record<string, unknown>>
   created_at: string
-  source_type?: "project" | "session"  // defaults to "project"
+  /**
+   * Dataset provenance:
+   * - "project" (default) — a real dataset materialised on disk
+   * - "session"           — a PostGIS-backed live session dataset
+   * - "virtual"           — a lazy worldwide catalog entry, not yet
+   *                         materialised (issue #238 / A12)
+   */
+  source_type?: "project" | "session" | "virtual"
   session_id?: string                   // set when source_type is "session"
+
+  // ─── Virtual dataset fields (worldwide aggregator, #238) ─────────────────
+  /** URI of the remote worldwide source backing a virtual dataset. */
+  virtual_source_uri?: string
+  /** Thematic data category of the virtual source. */
+  data_category?: string
+  /** Feature count of the previewed bbox; null until previewed. */
+  feature_count?: number | null
+  /** Bounding box used for the last preview/scan; null until previewed. */
+  virtual_bbox?: number[] | null
+  /** Worldwide catalog entry id this virtual dataset was created from. */
+  catalog_entry?: string
 }
 
 export interface CapabilitySchema {


### PR DESCRIPTION
## Summary

Implements **A12 / #238** — the **Worldwide** tab in the GISPulse portal, part of EPIC v1.9.0 #226 (global geo-data aggregator). The backend A10 endpoints are already live in prod; this PR is the portal-side consumer.

Users can now browse the worldwide catalog, pre-filter by jurisdiction, add entries as lazy **virtual** datasets, preview a bbox, and **materialize** a virtual dataset into a real on-disk dataset.

## What changed

**Types**
- `types/catalog.ts` — `WorldwideEntry`, `WorldwideFilters`
- `types/dataset.ts` — `source_type: "virtual"` + `virtual_source_uri` / `data_category` / `virtual_bbox` / `catalog_entry` / `feature_count` fields

**API**
- `api/catalog.ts` — `searchWorldwide`, `createVirtualDataset`, `previewVirtualDataset`, `materializeVirtualDataset` mapping the four A10 endpoints (`GET /worldwide`, `POST /virtual`, `GET /virtual/{id}/preview`, `POST /virtual/{id}/materialize`). `virtual_id` is passed verbatim since the backend declares it as `{id:path}`; only the bbox query string is encoded.
- `api/client.ts` — re-exports the four functions, consistent with the existing catalog barrel

**State**
- `stores/catalogStore.ts` — `worldwide` entries, `worldwideFilters` (jurisdiction pre-filter), `virtualDatasets` map, plus `setWorldwideFilters` / `fetchWorldwide` / `upsertVirtualDataset` / `removeVirtualDataset`. Re-uses the existing `AbortController` cancel pattern (#207).

**UI**
- `components/WorldwideEntryCard.tsx` (new) — gallery card; `virtual` badge after creation, flips to `project` badge after materialization
- `components/WorldwideMaterializeDialog.tsx` (new) — bbox-draw modal reusing `BBoxDrawMap`; **the Materialize button stays disabled until a bbox is drawn** (acceptance criterion); optional Preview call surfaces `feature_count`
- `CatalogImportDialog.tsx` — exports `BBoxDrawMap` for reuse (no behavior change)
- `CatalogWorkspace.tsx` — Worldwide sidebar tab, jurisdiction pre-filter section, worldwide gallery grid, virtual/materialize action wiring
- `panels/DatasetSection.tsx` — renders the `virtual` badge for virtual datasets

**i18n**
- `i18n/strings.ts` — FR + EN `worldwide.*` keys

**Tests**
- `__tests__/worldwideAggregator.test.tsx` (new) — 6 tests: store jurisdiction pre-filter + re-fetch, `fetchWorldwide`, virtual-dataset map actions, and the **Materialize button disabled without a bbox**

## Acceptance criteria

- [x] Gallery of worldwide entries displayed
- [x] Materialize button disabled without a bbox
- [x] `virtual` badge → `project` badge after materialization

## Verification

- `pnpm build` — passes
- `pnpm test` (vitest + happy-dom) — 456/456 pass (37 files), incl. 6 new
- `pnpm lint` — A12 files clean; the suite is pre-existing red (184 problems, **identical before and after this branch** — known stale portal CI baseline)

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)