### PR TITLE
fix(realign-2.0): sweep Dependabot CVE backlog (portal) + auto-merge patch/minor

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot auto-merge
+
+# Auto-merge Dependabot patch and minor updates after CI passes.
+# Major bumps remain manual (require human review).
+# Triggered as part of Realign 2.0 PR-P4 to stop the CVE drift backlog.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve patch/minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL" --body "Auto-approved (Dependabot patch/minor update)."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -60,5 +60,14 @@
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1",
     "vitest": "^4.1.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion": ">=5.0.6",
+      "fast-uri": ">=3.1.2",
+      "hono": ">=4.12.18",
+      "ip-address": ">=10.1.1",
+      "qs": ">=6.15.2"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,13 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion: '>=5.0.6'
+  fast-uri: '>=3.1.2'
+  hono: '>=4.12.18'
+  ip-address: '>=10.1.1'
+  qs: '>=6.15.2'
+
 importers:
 
   .:
@@ -462,7 +469,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.18'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -668,36 +675,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
@@ -773,24 +786,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -2001,24 +2018,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Summary

PR-P4 of the **Realign 2.0** sprint — burn down the Dependabot CVE backlog on `gispulse-portal` and stop the drift pattern recurring.

### CVE inventory (8 alerts, all transitive)

| # | Severity | Package | GHSA | Vulnerable | Patched | Status |
|---|---|---|---|---|---|---|
| 6 | HIGH | fast-uri | GHSA-v39h-62p7-jpjc | <= 3.1.1 | 3.1.2 | Fixed (3.1.2 via #103) |
| 3 | HIGH | fast-uri | GHSA-q3j6-qgpj-74h6 | <= 3.1.0 | 3.1.1 | Fixed (3.1.2 via #103) |
| 8 | MODERATE | qs | GHSA-q8mj-m7cp-5q26 | 6.11.1 - 6.15.1 | 6.15.2 | Fixed (6.15.2 via #103) |
| 7 | MODERATE | brace-expansion | GHSA-jxxr-4gwj-5jf2 | 5.0.0 - 5.0.5 | 5.0.6 | Fixed (5.0.6 via #103) |
| 5 | MODERATE | hono | GHSA-qp7p-654g-cw7p | < 4.12.18 | 4.12.18 | Fixed (4.12.19 via #103) |
| 2 | MODERATE | hono | GHSA-p77w-8qqv-26rm | < 4.12.18 | 4.12.18 | Fixed (4.12.19 via #103) |
| 1 | MODERATE | ip-address | GHSA-v2v4-37r5-5v8g | <= 10.1.0 | 10.1.1 | Fixed (10.2.0 via #103) |
| 4 | LOW | hono | GHSA-hm8q-7f3q-5f36 | < 4.12.18 | 4.12.18 | Fixed (4.12.19 via #103) |

All vulnerabilities are **transitive**. None of the packages appear in direct `dependencies` / `devDependencies`.

### What this PR does

1. **Dependabot PR #103 mergeable** — the weekly `minor-and-patch` group (19 updates) was approved and squashed. It transitively bumped all 5 vulnerable packages above their patched versions.
2. **Dependabot PR #104 closed** — standalone brace-expansion bump, superseded by #103.
3. **`pnpm.overrides` added** (belt-and-suspenders) — pins the five vulnerable packages to >= patched versions in `package.json` so a future direct dependency cannot pull a regressed range back in. Lockfile regenerated.
4. **Auto-merge workflow added** — `.github/workflows/dependabot-auto-merge.yml` auto-approves and squash-merges patch+minor Dependabot PRs once CI passes. Majors stay manual.

### Residual risk

- **None on direct deps** — overrides are belt-and-suspenders.
- **Major bumps still manual** — by design. Auto-merge gated on `update-type == patch || minor`.
- **Conflict potential** — touches `package.json` (overrides only) and `.github/workflows/` (new file). No expected conflict with P1/P2/P3.

## Test plan

- [x] Lockfile regenerated locally with `pnpm install --lockfile-only`
- [x] All 5 vulnerable packages locked to patched versions (verified `grep` on `pnpm-lock.yaml`)
- [ ] CI green on this PR (frontend + CodeQL + GitGuardian)
- [ ] After merge, Dependabot alerts page shows 0 open alerts (rescan ~1h)
- [ ] Next weekly Dependabot run auto-merges patch+minor group without manual intervention

Closes #109
Refs EPIC https://github.com/imagodata/gispulse/issues/327