### PR TITLE
ci(release): publish @gispulse/portal-libre to npm (closes #114)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,9 @@ jobs:
           fi
 
       - name: Verify package.json version matches pyproject.toml
-        # Runs unconditionally (both push-tag and workflow_dispatch) — npm
-        # side has historically drifted because the previous assertion
-        # only covered pyproject ↔ __init__ ↔ tag. Lockstep matters even
-        # if npm publish is not (yet) part of this workflow.
+        # Runs unconditionally (both push-tag and workflow_dispatch). The
+        # `publish-npm` job below uses the same `package.json` version, so
+        # this guarantees PyPI ↔ npm lockstep.
         run: |
           PKG_JSON_V=$(jq -r .version package.json)
           PYPROJECT_V=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
@@ -137,7 +136,75 @@ jobs:
         with:
           packages-dir: ${{ env.PY_DIST_DIR }}
 
-  # ── 2. Create GitHub Release with sdist + wheel attached ────────────
+  # ── 2. Publish @gispulse/portal-libre to npm ────────────────────────
+  publish-npm:
+    name: Publish @gispulse/portal-libre to npm
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || inputs.dry_run == false
+    environment: npm  # Requires GH Settings → Environments → `npm` with NPM_TOKEN.
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install JS dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SPA (pnpm build → ./dist)
+        # npm package ships `./dist` for downstream Vite consumers (see
+        # `files` in package.json). Keep build symmetric with publish-pypi.
+        run: pnpm build
+
+      - name: Assert package name and access
+        # Fail fast if someone renames the npm package or flips access to
+        # restricted by accident (we publish under the public registry).
+        run: |
+          NAME=$(jq -r .name package.json)
+          ACCESS=$(jq -r '.publishConfig.access // "default"' package.json)
+          echo "name=$NAME access=$ACCESS"
+          if [ "$NAME" != "@gispulse/portal-libre" ]; then
+            echo "::error::Unexpected npm package name: $NAME"
+            exit 1
+          fi
+          if [ "$ACCESS" != "public" ]; then
+            echo "::error::publishConfig.access must be 'public' for scoped pkg"
+            exit 1
+          fi
+
+      - name: Check npm registry for existing version (idempotent re-run)
+        # Re-running the workflow on an already-published version is a
+        # common operator action (e.g. CI flake). Detect it and skip the
+        # publish step instead of failing with E_PUBLISH_CONFLICT.
+        id: npm_exists
+        run: |
+          VERSION=$(jq -r .version package.json)
+          if npm view "@gispulse/portal-libre@${VERSION}" version 2>/dev/null; then
+            echo "Version already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm (public, with provenance)
+        if: steps.npm_exists.outputs.skip == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # `--provenance` requires `id-token: write` (set at workflow level)
+        # and produces a signed Sigstore attestation linking the artefact
+        # to this exact GitHub Actions run. Consumer-visible on npmjs.com.
+        run: npm publish --access public --provenance
+
+  # ── 3. Create GitHub Release with sdist + wheel attached ────────────
   github-release:
     name: Create GitHub Release
     needs: publish-pypi


### PR DESCRIPTION
## Summary

- Adds a `publish-npm` job to `.github/workflows/release.yml` so each tag-driven release ships **both** PyPI (`gispulse-portal`) and npm (`@gispulse/portal-libre`) in lockstep.
- Job runs after `publish-pypi` (fails together if PyPI fails) and uses `--provenance` (Sigstore attestation) — works because the workflow already declares `id-token: write`.
- Idempotent: skips publish if the version is already on npm (handles CI re-runs cleanly).
- Asserts `package.json` name == `@gispulse/portal-libre` and `publishConfig.access == "public"` to fail fast on accidental drift.

## Why now

Since v2.0.0 the npm package returns 404 (`npm view @gispulse/portal-libre` → not in registry) even though `package.json` advertises `publishConfig.access: public`. `@gispulse/portal-pro` declares `peerDependencies` against `@gispulse/portal-libre@^2.0.0` — unsatisfiable until this lands.

## Required operator action (cannot be done from this PR)

This PR is **inert** until a maintainer creates:

- **GitHub Settings → Environments → `npm`** with:
  - Secret `NPM_TOKEN` — npmjs.com → Access Tokens → Granular, scope `Publish`, package `@gispulse/portal-libre`
  - (Recommended) `Deployment branches and tags: tags only`, mirroring the existing `pypi` environment policy
  - (Recommended) `Wait timer: 5 min`, same as `pypi`

Once that's in place, the next tag-driven release (v2.0.1+) will publish both targets automatically.

## Test plan

- [x] YAML syntax validated locally (`python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`)
- [ ] Workflow visible in Actions tab after merge
- [ ] After `NPM_TOKEN` is provisioned: `workflow_dispatch` with `dry_run: false` against `v2.0.0` tag to backfill the missing npm release **OR** wait for next semver bump (v2.0.1)
- [ ] Verify `npm view @gispulse/portal-libre@2.0.0` returns metadata
- [ ] Verify `npm view @gispulse/portal-libre@2.0.0 --json | jq .dist.attestations` shows provenance

Closes #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)